### PR TITLE
Setup PZP msg handler again when PZH disappears.

### DIFF
--- a/webinos/pzp/lib/pzp_sessionHandling.js
+++ b/webinos/pzp/lib/pzp_sessionHandling.js
@@ -328,6 +328,7 @@
 				self.pzhId     = '';
 				self.sessionId = self.config.details.name;
 				self.rpcHandler.setSessionId(self.sessionId);
+				setupMessageHandler(self);
 
 				websocket.updateInstance(instance);
 


### PR DESCRIPTION
Otherwise the msg handler tries to forward the msg and fails, because
it is not aware of the new name the PZP assumed after the PZH
disconnected.

http://jira.webinos.org/browse/WP-50
