### PR TITLE
`webinos.path.relative` returns wrong relative path

### DIFF
--- a/webinos/api/file/lib/webinos.path.js
+++ b/webinos/api/file/lib/webinos.path.js
@@ -247,8 +247,29 @@ if (typeof module === "undefined") {
 	 * TODO Check if paths are absolute (resolve if not? fallback prefix?).
 	 */
 	exports.relative = function (from, to) {
-		var fromParts = exports.normalize(from).split("/"),
-			toParts = exports.normalize(to).split("/");
+		function trim (array) {
+			var start;
+			for (start = 0; start < array.length; start++) {
+				if (array[start] !== "") {
+					break;
+				}
+			}
+
+			var end;
+			for (end = array.length - 1; end >= 0; end--) {
+				if (array[end] !== "") {
+					break;
+				}
+			}
+
+			if (start > end)
+				return [];
+
+			return array.slice(start, end - start + 1);
+		}
+
+		var fromParts = trim(exports.normalize(from).substr(1).split("/")),
+			toParts = trim(exports.normalize(to).substr(1).split("/"));
 
 		var length = Math.min(fromParts.length, toParts.length),
 			samePartsLength = length;


### PR DESCRIPTION
Jira issue: [WP-54](http://jira.webinos.org/browse/WP-54)

Full review of `webinos.path` planned for alpha release 0.6 (see [WP-53](http://jira.webinos.org/browse/WP-53)).
