### PR TITLE
Use length framing instead of delimiter for JSON over socket

### DIFF
--- a/webinos/pzh/lib/pzh_sessionHandling.js
+++ b/webinos/pzh/lib/pzh_sessionHandling.js
@@ -128,7 +128,7 @@ Pzh.prototype.sendMessage = function (message, address, conn) {
 			log(self.sessionId, 'INFO', '[PZH -'+ self.sessionId+'] Client ' + address + ' is not connected');
 		}
 	} catch(err) {
-		log(self.sessionId, 'ERROR ','[PZH -'+ self.sessionId+'] Exception in sending packet ' + err);
+		log(self.sessionId, 'ERROR', '[PZH -'+ self.sessionId+'] Exception in sending packet ' + err);
 	}
 };
 
@@ -170,7 +170,7 @@ Pzh.prototype.handleConnectionAuthorization = function (self, conn) {
 			var text = decodeURIComponent(cn);
 			data = text.split(':');
 		} catch(err) {
-			log(self.sessionId, 'ERROR ','[PZH  -'+self.sessionId+'] Exception in reading common name of peer PZH certificate ' + err);
+			log(self.sessionId, 'ERROR', '[PZH  -'+self.sessionId+'] Exception in reading common name of peer PZH certificate ' + err);
 			return;
 		}
 		/**
@@ -181,7 +181,7 @@ Pzh.prototype.handleConnectionAuthorization = function (self, conn) {
 			try {
 				pzhId = data[1];
 			} catch (err1) {
-				log(self.sessionId, 'ERROR ','[PZH -'+self.sessionId+'] Pzh information in certificate is in unrecognized format ' + err1);
+				log(self.sessionId, 'ERROR', '[PZH -'+self.sessionId+'] Pzh information in certificate is in unrecognized format ' + err1);
 				return;
 			}
 
@@ -209,7 +209,7 @@ Pzh.prototype.handleConnectionAuthorization = function (self, conn) {
 			try {
 				sessionId = self.sessionId+'/'+data[1];
 			} catch(err1) {
-				log(self.sessionId, 'ERROR ','[PZH  -' + self.sessionId + '] Exception in reading common name of PZP certificate ' + err1);
+				log(self.sessionId, 'ERROR', '[PZH  -' + self.sessionId + '] Exception in reading common name of PZP certificate ' + err1);
 				return;
 			}
 
@@ -265,7 +265,7 @@ Pzh.prototype.handleData = function(conn, buffer) {
 			self.processMsg(conn, obj);
 		});
 	} catch (err) {
-		log(this.sessionId, 'ERROR ', '[PZH] Exception in processing recieved message ' + err);
+		log(this.sessionId, 'ERROR', '[PZH] Exception in processing recieved message ' + err);
 	} finally {
 		conn.resume();
 	}
@@ -311,7 +311,7 @@ Pzh.prototype.addNewPZPCert = function (parse, cb) {
 		});
 
 	} catch (err) {
-		log(self.sessionId, 'ERROR ', '[PZH -'+self.sessionId+'] Error Signing Client Certificate' + err);
+		log(self.sessionId, 'ERROR', '[PZH -'+self.sessionId+'] Error Signing Client Certificate' + err);
 		cb.call(self, "Could not create client certificate");
 	}
 }
@@ -386,7 +386,7 @@ exports.addPzh = function ( uri, modules, callback) {
 		callback(false);
 	} else {
 		if (typeof uri === "undefined" || uri === 'null' || typeof modules === "undefined" || modules === 'null' ){
-			log(null, 'ERROR','PZH could not be started as one of the details are missing ');
+			log(null, 'ERROR', 'PZH could not be started as one of the details are missing ');
 			callback(false);
 		} else {
 			var name = uri.split('/')[1];

--- a/webinos/pzh/lib/pzh_sessionHandling.js
+++ b/webinos/pzh/lib/pzh_sessionHandling.js
@@ -102,21 +102,24 @@ Pzh.prototype.prepMsg = function (from, to, status, message) {
 * @param {Object} conn This is used in special cases, especially when Pzh and Pzp are not connected.
 */
 Pzh.prototype.sendMessage = function (message, address, conn) {
-	var buf, self = this;
+	var self = this;
+
+	var jsonString = JSON.stringify(message);
+	var buf = new Buffer(4 + jsonString.length, 'utf8');
+	buf.writeUInt32LE(jsonString.length, 0);
+	buf.write(jsonString, 4);
+
+	log(self.sessionId, 'INFO', '[PZH -'+ self.sessionId+'] Send to '+ address + ' Message ' + jsonString);
+	
 	try {
-		/** TODO: This is a temporary solution to append message with #. This is done in order to identify whole message at receiving end */
-		log(self.sessionId, 'INFO', '[PZH -'+ self.sessionId+'] Send to '+ address + ' Message '+JSON.stringify(message));
-		buf = new Buffer('#'+JSON.stringify(message)+'#', 'utf8');
 		if (self.connectedPzh.hasOwnProperty(address)) {
 			self.connectedPzh[address].socket.pause();
 			self.connectedPzh[address].socket.write(buf);
 			self.connectedPzh[address].socket.resume();
-
 		} else if (self.connectedPzp.hasOwnProperty(address)) {
 			self.connectedPzp[address].socket.pause();
 			self.connectedPzp[address].socket.write(buf);
 			self.connectedPzp[address].socket.resume();
-
 		} else if( typeof conn !== "undefined" ) {
 			conn.pause();
 			conn.write(buf);
@@ -126,7 +129,6 @@ Pzh.prototype.sendMessage = function (message, address, conn) {
 		}
 	} catch(err) {
 		log(self.sessionId, 'ERROR ','[PZH -'+ self.sessionId+'] Exception in sending packet ' + err);
-
 	}
 };
 
@@ -251,17 +253,23 @@ Pzh.prototype.handleConnectionAuthorization = function (self, conn) {
 /**
 	* @description: Calls processmsg to handle incoming message to PZH. This is called by PZH Farm
 	* @param {Object} conn: Socket connection details of client socket ..
-	* @param {String} data: Incoming data received from other PZH or PZP
+	* @param {Buffer} buffer: Incoming data received from other PZH or PZP
 	*/
-Pzh.prototype.handleData = function(conn, data) {
+Pzh.prototype.handleData = function(conn, buffer) {
+	var self = this;
+	
 	try {
 		conn.pause();
-		this.processMsg(conn, data);
-		conn.resume();
+		
+		session.common.readJson(self, buffer, function(obj) {
+			self.processMsg(conn, obj);
+		});
 	} catch (err) {
 		log(this.sessionId, 'ERROR ', '[PZH] Exception in processing recieved message ' + err);
+	} finally {
+		conn.resume();
 	}
-}
+};
 
 /**
 	* @description: Sets PZH URL id for storing information about QRCode
@@ -307,61 +315,51 @@ Pzh.prototype.addNewPZPCert = function (parse, cb) {
 		cb.call(self, "Could not create client certificate");
 	}
 }
-/**
-* @description process incoming messages, message of type prop are only received while session is established. Rest of the time it is usually RPC messages
-* @param {Object} conn: It is used in special scenarios, when PZP is not connected and we need to send response back
-* @param {data} data: Actual data received from other PZH or PZP.
-*/
-Pzh.prototype.processMsg = function(conn, data) {
-	var self = this;
-	// ProcessedMsg handles message coming in small chunks.
-	session.common.processedMsg(self, data, function(message) {
-		// Sometime messages are accumulated, thsi allows going through combined message received
-		for (var i = 1 ; i < (message.length-1); i += 1 ) {
-			if (message[i] === '') {
-				continue;
-			}
-			// Parse each individual message
-			log(self.sessionId, 'DEBUG', '[PZH -'+self.sessionId+'] Received message' + message[i])
-			var parse= JSON.parse(message[i]);
 
-			// Message sent by PZP connecting first time based on this message it generates client certificate
-			if(parse.type === 'prop' && parse.payload.status === 'clientCert' ) {
-				self.addNewPZPCert(parse, function(err, msg) {
-					if (err !== null) {
-						log(self.sessionId, 'INFO', err);
-						return;
-					} else {
-						self.sendMessage(msg, parse.from,conn);
-					}
-				});
-			}
-			// information sent by connecting PZP about services it supports. These details are then used by findServices
-			else if(parse.type === "prop" && parse.payload.status === 'registerServices') {
-				log(self.sessionId, 'INFO', '[PZH -'+ self.sessionId+'] Receiving Webinos Services from PZP...');
-				self.rpcHandler.addRemoteServiceObjects(parse.payload.message);
-			}
-			// Send findServices information to connected PZP..
-			else if(parse.type === "prop" && parse.payload.status === 'findServices') {
-				log(self.sessionId, 'INFO', '[PZH -'+ self.sessionId+'] Trying to send Webinos Services from this RPC handler to ' + parse.from + '...');
-				var services = self.rpcHandler.getAllServices(parse.from);
-				var msg = self.prepMsg(self.sessionId, parse.from, 'foundServices', services);
-				msg.payload.id = parse.payload.message.id;
-				self.sendMessage(msg, parse.from);
-				log(self.sessionId, 'INFO', '[PZH -'+ self.sessionId+'] Sent ' + (services && services.length) || 0 + ' Webinos Services from this RPC handler.');
-			}
-			// Message is forwarded to Messaging manager
-			else {
-				try {
-					self.messageHandler.onMessageReceived(parse, parse.to);
-				} catch (err2) {
-					log(self.sessionId, 'ERROR', '[PZH -'+ self.sessionId+'] Error Message Sending to Messaging ' + err2);
+/**
+ * @description process incoming messages, message of type prop are only received while session is established. Rest of the time it is usually RPC messages
+ * @param {Object} conn: It is used in special scenarios, when PZP is not connected and we need to send response back
+ * @param {Object} msgObj: A message object received from other PZH or PZP.
+ */
+Pzh.prototype.processMsg = function(conn, msgObj) {
+	var self = this;
+	session.common.processedMsg(self, msgObj, function(validMsgObj) {
+		log(self.sessionId, 'DEBUG', '[PZH -'+self.sessionId+'] Received message' + JSON.stringify(validMsgObj));
+		// Message sent by PZP connecting first time based on this message it generates client certificate
+		if(validMsgObj.type === 'prop' && validMsgObj.payload.status === 'clientCert' ) {
+			self.addNewPZPCert(validMsgObj, function(err, msg) {
+				if (err !== null) {
+					log(self.sessionId, 'INFO', err);
 					return;
+				} else {
+					self.sendMessage(msg, validMsgObj.from, conn);
 				}
+			});
+		}
+		// information sent by connecting PZP about services it supports. These details are then used by findServices 
+		else if(validMsgObj.type === "prop" && validMsgObj.payload.status === 'registerServices') {
+			log(self.sessionId, 'INFO', '[PZH -'+ self.sessionId+'] Receiving Webinos Services from PZP...');
+			self.rpcHandler.addRemoteServiceObjects(validMsgObj.payload.message);
+		}
+		// Send findServices information to connected PZP..
+		else if(validMsgObj.type === "prop" && validMsgObj.payload.status === 'findServices') {
+			log(self.sessionId, 'INFO', '[PZH -'+ self.sessionId+'] Trying to send Webinos Services from this RPC handler to ' + validMsgObj.from + '...');
+			var services = self.rpcHandler.getAllServices(validMsgObj.from);
+			var msg = self.prepMsg(self.sessionId, validMsgObj.from, 'foundServices', services);
+			msg.payload.id = validMsgObj.payload.message.id;
+			self.sendMessage(msg, validMsgObj.from);
+			log(self.sessionId, 'INFO', '[PZH -'+ self.sessionId+'] Sent ' + (services && services.length) || 0 + ' Webinos Services from this RPC handler.');
+		}
+		// Message is forwarded to Messaging manager
+		else {
+			try {
+				self.messageHandler.onMessageReceived(validMsgObj, validMsgObj.to);
+			} catch (err2) {
+				log(self.sessionId, 'ERROR', '[PZH -'+ self.sessionId+'] Error Message Sending to Messaging ' + err2);
+				return;
 			}
 		}
-
-	});
+	});	
 };
 
 Pzh.prototype.setMessageHandler = function() {

--- a/webinos/pzp/lib/session_common.js
+++ b/webinos/pzp/lib/session_common.js
@@ -186,17 +186,17 @@ session_common.processedMsg = function(self, msgObj, callback) {
 	// BEGIN OF POLITO MODIFICATIONS
 	var valError = validation.checkSchema(msgObj);
 	if(valError === false) { // validation error is false, so validation is ok
-		common.debug('DEBUG','[VALIDATION] Received recognized packet ' + JSON.stringify(msgObj));
+		session_common.debug('DEBUG','[VALIDATION] Received recognized packet ' + JSON.stringify(msgObj));
 	} else if (valError === true) {
 		// for debug purposes, we only print a message about unrecognized packet
 		// in the final version we should throw an error
 		// Currently there is no a formal list of allowed packages and throw errors
 		// would prevent the PZH from working
-		common.debug('INFO','[VALIDATION] Received unrecognized packet ' + JSON.stringify(msgObj));
+		session_common.debug('INFO','[VALIDATION] Received unrecognized packet ' + JSON.stringify(msgObj));
 	} else if (valError === 'failed') {
-		common.debug('ERROR','[VALIDATION] failed');
+		session_common.debug('ERROR','[VALIDATION] failed');
 	} else {
-		common.debug('ERROR','[VALIDATION] Invalid response ' + valError);
+		session_common.debug('ERROR','[VALIDATION] Invalid response ' + valError);
 	}
 	callback.call(self, msgObj);
 };

--- a/webinos/pzp/lib/session_common.js
+++ b/webinos/pzp/lib/session_common.js
@@ -115,14 +115,6 @@ session_common.webinosConfigPath = function() {
 	return webinosDemo;
 };
 
-// global exception handler, which catches all unhandled exceptions,
-// prints a trace and exits. the trace is better than the default.
-/*process.addListener("uncaughtException", function (err) {
-    console.log("Uncaught exception: " + err);
-    console.trace();
-    process.exit();
-});*/
-
 /** @desription It removes the connected PZP/Pzh details.
  */
 session_common.removeClient = function(self, conn) {
@@ -139,57 +131,74 @@ session_common.removeClient = function(self, conn) {
 };
 
 /**
+ * Read in JSON objects from buffer and call objectHandler for each parsed
+ * object.
+ * @param buffer Buffer instance containing JSON serialized objects.
+ * @param objectHandler Callback for parsed object.s
+ */
+var instanceMap = {};
+session_common.readJson = function(instance, buffer, objectHandler) {
+	var jsonStr;
+	var len;
+	var offset = 0;
+	
+	for (;;) {
+		if (instanceMap[instance]) {
+			// we already read from a previous buffer, read the rest
+			len = instanceMap[instance].restLen;
+			jsonStr = instanceMap[instance].part;
+			jsonStr += buffer.toString('utf8', offset, offset + len);
+			offset += len;
+			instanceMap[instance] = undefined;
+			
+		} else {
+			len = buffer.readUInt32LE(offset);
+			jsonStr = buffer.toString('utf8', offset + 4, offset + len + 4);
+			offset += len + 4;
+		}
+		
+		if (jsonStr.length < len) {
+			instanceMap[instance] = {
+					restLen: len - jsonStr.length,
+					part: jsonStr
+			}
+			return;
+		}
+		
+		// call handler with parsed message object
+		objectHandler(JSON.parse(jsonStr));
+		
+		if (offset >= buffer.length) {
+			// finished reading buffer
+			return;
+		}
+	}
+};
+
+/**
  * This function is call most as each data received first calls this function.
  * It removes appended # in the message. This is appended at both end to identify start and end of message.
  * Also message verify is done based on schema. 
  */
-session_common.processedMsg = function(self, data, callback) {
+session_common.processedMsg = function(self, msgObj, callback) {
 	"use strict";
-	var msg = data.toString('utf8');
-	var dataLen = 1;
-	// This part of the code is executed when message comes in chunks 
-	// First part of the message coming in
-	if (msg[0] === '#' && msg[msg.length-dataLen] !== '#') {
-		message = msg;
-		return;
-	}
-	// This is the middle of the message
-	if (msg[0] !== '#' && msg[msg.length-dataLen] !== '#') {
-		message += msg;
-		return;
-	}
-	// This is the last part of the message
-	if (msg[0] !== '#' && msg[msg.length-dataLen] === '#') {
-		message += msg;
-		msg = message;
-
-		message = '';
-	}
 	
-	if(msg[0] ==='#' && msg[msg.length-dataLen] === '#') {
-		msg = msg.split('#');
-		
-		var parse = JSON.parse(msg[1]);
-		// BEGIN OF POLITO MODIFICATIONS
-		for (var i = 1 ; i < parse.length-1; i += 1) {
-			var valError = validation.checkSchema(parse[i]);
-			if(valError === false) { // validation error is false, so validation is ok
-				common.debug('DEBUG','[VALIDATION] Received recognized packet ' + JSON.stringify(parse[i]));
-			} else if (valError === true) {
-				// for debug purposes, we only print a message about unrecognized packet
-				// in the final version we should throw an error
-				// Currently there is no a formal list of allowed packages and throw errors
-				// would prevent the PZH from working
-				common.debug('INFO','[VALIDATION] Received unrecognized packet ' + JSON.stringify(parse[i]));
-			} else if (valError === 'failed') {
-				common.debug('ERROR','[VALIDATION] failed');
-			} else {
-				common.debug('ERROR','[VALIDATION] Invalid response ' + valError);
-			}
-		}
-		callback.call(self, msg);
+	// BEGIN OF POLITO MODIFICATIONS
+	var valError = validation.checkSchema(msgObj);
+	if(valError === false) { // validation error is false, so validation is ok
+		common.debug('DEBUG','[VALIDATION] Received recognized packet ' + JSON.stringify(msgObj));
+	} else if (valError === true) {
+		// for debug purposes, we only print a message about unrecognized packet
+		// in the final version we should throw an error
+		// Currently there is no a formal list of allowed packages and throw errors
+		// would prevent the PZH from working
+		common.debug('INFO','[VALIDATION] Received unrecognized packet ' + JSON.stringify(msgObj));
+	} else if (valError === 'failed') {
+		common.debug('ERROR','[VALIDATION] failed');
+	} else {
+		common.debug('ERROR','[VALIDATION] Invalid response ' + valError);
 	}
-
+	callback.call(self, msgObj);
 };
 
 /**


### PR DESCRIPTION
For each JSON string serialized message object to send, use a Buffer
prefixed with four octets for an unsigned int (little endian) that
specifies the length of the serialized message.

http://jira.webinos.org/browse/WP-49
