### PR TITLE
Fix build to work on Windows.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,16 +3,16 @@
     {
     'target_name':'webinos',
     'dependencies': [
-      'webinos/common/manager/certificate_manager/src/binding.gyp:certificate_manager',
+      'webinos/common/manager/certificate_manager/binding.gyp:certificate_manager',
       'webinos/common/manager/policy_manager/src/binding.gyp:pm',
       'webinos/api/contacts/src/binding.gyp:localcontacts',
       'webinos/api/devicestatus/src/binding.gyp:devicestatus',
-      'webinos_wrt#host'
+      'webinos_wrt#host',
     ],
     'conditions': [ 
-      [ 'OS=="freebsd" or OS=="openbsd" or OS=="solaris" or (OS=="linux" and target_arch!="ia32")', {
+      [ 'OS!="win"', {
         'dependencies': [
-          'webinos/api/discovery/src/binding.gyp:bluetooth'
+          'webinos/api/discovery/src/binding.gyp:bluetooth',
           ],
         },
       ],
@@ -22,62 +22,16 @@
     'target_name': 'webinos_wrt',
     'type': 'none',
     'toolsets': ['host'],
-    'actions': [
+    'copies': [
       {
-        'action_name': 'webinos_wrt',
-
-        'inputs': [
-          './tools/closure-compiler/compiler.jar',
+        'files': [
+          'build/Release/certificate_manager.node',
+          'build/Release/localcontacts.node',
+          'build/Release/bluetooth.node',
+          'build/Release/nativedevicestatus.node',
+          'build/Release/pm.node',
         ],
-
-        'outputs': [
-          './webinos/test/client/webinos.js',
-        ],
-
-        # FIXME can the following conditions be shorted by just setting
-        # macros.py into some variable which then gets included in the
-        # action?
-        'action': [
-          'java',
-          '-jar',
-          './tools/closure-compiler/compiler.jar',
-          '--compilation_level',
-          'WHITESPACE_ONLY',
-          '--warning_level',
-          'VERBOSE',
-          "--js", "./webinos/common/rpc/lib/rpc.js",
-          "--js", "./webinos/common/manager/messaging/lib/messagehandler.js",
-          "--js", "./webinos/wrt/lib/webinos.session.js",
-          "--js", "./webinos/wrt/lib/webinos.servicedisco.js",
-          "--js", "./webinos/wrt/lib/webinos.js",
-          "--js", "./webinos/common/rpc/lib/webinos.utils.js",
-          "--js", "./webinos/api/file/lib/webinos.path.js",
-          "--js", "./webinos/wrt/lib/webinos.file.js",
-          "--js", "./webinos/wrt/lib/webinos.tv.js",
-          "--js", "./webinos/wrt/lib/webinos.oauth.js",
-          "--js", "./webinos/wrt/lib/webinos.get42.js",
-          "--js", "./webinos/wrt/lib/webinos.geolocation.js",
-          "--js", "./webinos/wrt/lib/webinos.sensors.js",
-          "--js", "./webinos/wrt/lib/webinos.events.js",
-          "--js", "./webinos/wrt/lib/webinos.applauncher.js",
-          "--js", "./webinos/wrt/lib/webinos.vehicle.js",
-          "--js", "./webinos/wrt/lib/webinos.deviceorientation.js",
-          "--js", "./webinos/wrt/lib/webinos.devicestatus.js",
-          "--js", "./webinos/wrt/lib/webinos.context.js",
-          "--js", "./webinos/wrt/lib/webinos.contacts.js",
-          "--js", "./webinos/wrt/lib/webinos.discovery.js",
-          "--js", "./webinos/wrt/lib/webinos.authentication.js",
-          "--js_output_file","<@(_outputs)",
-        ],
-        'action': [
-          'cp', 
-          './build/Release/certificate_manager.node',
-          './build/Release/localcontacts.node',
-          './build/Release/bluetooth.node',
-          './build/Release/nativedevicestatus.node',
-          './build/Release/pm.node',
-          './node_modules/',
-        ]
+        'destination': 'node_modules/',
       }],
     }, # end webinos_wrt
   ], 

--- a/webinos/common/manager/certificate_manager/binding.gyp
+++ b/webinos/common/manager/certificate_manager/binding.gyp
@@ -7,9 +7,10 @@
     {
        # Needed declarations for the target
       'target_name': 'certificate_manager',
+      'product_name': 'certificate_manager',
         'sources': [ #Specify your source files here
-          'certificate_manager.cpp',
-          'openssl_wrapper.cpp',
+          'src/certificate_manager.cpp',
+          'src/openssl_wrapper.cpp',
         ],
       
       'conditions': [

--- a/webinos/common/manager/certificate_manager/package.json
+++ b/webinos/common/manager/certificate_manager/package.json
@@ -1,7 +1,7 @@
 { "name": "certificate_manager"
 , "description": "An interface to OpenSSL's certificate creation and revocation functions"
-, "version": "1"
-, "main": "src/build/Release/certificate_manager.node"
+, "version": "0.0.1"
+, "main": "build/Release/certificate_manager.node"
 , "keywords": ["OpenSSL","Crypto","Certificate","CRL"]
 , "maintainers": [{ "name": "John Lyle"}]
 , "contributors": [{ "name": "John Lyle"}]
@@ -14,9 +14,4 @@
     , "url": "http://github.com/isaacs/npm/raw/master/LICENSE"
     }
   ]
-, "repositories": 
-  [ { "type" : "git",
-      "url"  : "http://dev.webinos.org/git/wp4.git"
-    }
-  ] 
 }


### PR DESCRIPTION
Remove node-gyp action to generate webinos.js.
Use copy section to copy compiled .node modules, works on all
platforms.

http://jira.webinos.org/browse/WP-64
