### PR TITLE
Bug fixes: certificate manager linking on 32 bit and proper logging initialization

### DIFF
--- a/webinos/common/manager/certificate_manager/binding.gyp
+++ b/webinos/common/manager/certificate_manager/binding.gyp
@@ -19,7 +19,7 @@
           'libraries': ['-l<(openssl_Root)/lib/libeay32.lib' ],
           'include_dirs': ['<(openssl_Root)/include'],
         }],
-        [ 'OS=="freebsd" or OS=="openbsd" or OS=="solaris" or (OS=="linux" and target_arch!="ia32")', {
+        [ 'OS=="freebsd" or OS=="openbsd" or OS=="solaris" or (OS=="linux")', {
           'libraries': ['-lssl', '-lcrypto'],
         }],
       ],  

--- a/webinos/pzp/lib/session_certificate.js
+++ b/webinos/pzp/lib/session_certificate.js
@@ -16,7 +16,8 @@
 * Copyright 2011 Habib Virji, Samsung Electronics (UK) Ltd
 *******************************************************************************/
 
-var log  = new require("./session_common").debug("cert");
+var log1  =  require("./session_common");
+var log   =  new log1.debug("cert");
 
 /** @description Create private key, certificate request, self signed certificate and empty crl. This is crypto sensitive function
  * @param {Object} self is currect object of Pzh/Pzp


### PR DESCRIPTION
Certificate manager should now compile on 32 bit
Logging object in session_certificate is initialized now correctly

Jira-issue: WP-69
