### PR TITLE
Added *_NotImplemented classes for bluetooth and keystore

### DIFF
--- a/webinos/api/discovery/src/bluetooth_NotImplemented.cc
+++ b/webinos/api/discovery/src/bluetooth_NotImplemented.cc
@@ -1,0 +1,67 @@
+// TODO: Implement bluetooth on windows
+#include <v8.h>
+#include <node.h>
+
+using namespace node;
+using namespace v8;
+
+
+class BTDiscovery: ObjectWrap
+{
+  public:
+
+  static Persistent<FunctionTemplate> s_ct;
+
+  static void Init(Handle<Object> target)
+  {
+    HandleScope scope;
+
+    Local<FunctionTemplate> t = FunctionTemplate::New(New);
+
+    s_ct = Persistent<FunctionTemplate>::New(t);
+    s_ct->InstanceTemplate()->SetInternalFieldCount(1);
+    s_ct->SetClassName(String::NewSymbol("BT"));
+
+    NODE_SET_PROTOTYPE_METHOD(s_ct, "scan_device", Scan_device);
+
+    NODE_SET_PROTOTYPE_METHOD(s_ct, "file_transfer", File_transfer);
+    
+    target->Set(String::NewSymbol("bluetooth"), s_ct->GetFunction());
+  }
+
+  BTDiscovery()
+  {
+  }
+
+  ~BTDiscovery()
+  {
+  }
+
+  static Handle<Value> New(const Arguments& args)
+  {
+    HandleScope scope;
+    BTDiscovery* bd = new BTDiscovery();
+    bd->Wrap(args.This());
+    return args.This();
+  }
+
+  static Handle<Value> Scan_device(const Arguments& args)
+  {
+	throw "Not implemented yet";
+  }
+
+  static Handle<Value> File_transfer(const Arguments& args)
+  {
+    throw "Not implemented yet";
+  }
+};
+Persistent<FunctionTemplate> BTDiscovery::s_ct;
+
+extern "C" {
+  static void init (Handle<Object> target)
+  {
+	  BTDiscovery::Init(target);
+  }
+
+  NODE_MODULE(bluetooth, init);
+}

--- a/webinos/common/manager/keystore/src/binding.gyp
+++ b/webinos/common/manager/keystore/src/binding.gyp
@@ -22,7 +22,7 @@
         }],
         [ 'OS=="win"', {
 		  'sources': [            
-			'ksImpl_Win.cpp',
+			'ksImpl_NotImplemented.cpp',
 		  ],
         }],
 		[ 'OS=="linux"', {

--- a/webinos/common/manager/keystore/src/ksImpl_NotImplemented.cpp
+++ b/webinos/common/manager/keystore/src/ksImpl_NotImplemented.cpp
@@ -1,0 +1,25 @@
+#include "ksImpl.h"
+
+//TODO: Implement keystore
+
+
+int __get(const char * svc, void ** secret) throw(::KeyStoreException)
+{
+	throw ::KeyStoreException("Key store is not yet implemented");
+}
+
+void __put(const char * svc, void * secret) throw(::KeyStoreException)
+{
+	throw ::KeyStoreException("Key store is not yet implemented");
+}
+
+void __freeSecretResource(void * secret) throw(::KeyStoreException)
+{
+	throw ::KeyStoreException("Key store is not yet implemented");
+}
+
+void __delete(const char * svc) throw(::KeyStoreException)
+{
+	throw ::KeyStoreException("Key store is not yet implemented");
+}
+


### PR DESCRIPTION
Added *_NotImplemented classes for bluetooth and keystore
Renamed module.gyp file in keystore to binding.gyp and updated it to look for the notimplemented version on window.
Discovery's binding must be updated after merging the wp-71 jira issue (https://github.com/webinos/Webinos-Platform/pull/38) .
