### PR TITLE
File API crashes PZP when port is already in use

### DIFF
--- a/webinos/api/file/lib/webinos.file.hack.js
+++ b/webinos/api/file/lib/webinos.file.hack.js
@@ -1,8 +1,14 @@
 (function () {
 	var nConnect = require("connect"),
+		nHttp = require("http"),
 		nPath = require("path");
-
-	nConnect()
-		.use(nConnect.static(nPath.join(process.cwd(), "default")))
+	
+	var app = nConnect().use(nConnect.static(nPath.join(process.cwd(), "default")));
+	
+	nHttp
+		.createServer(app)
+		.on("error", function (error) {
+			console.log("webinos.file.hack.js: Error starting `connect` middleware (" + error + ").");
+		})
 		.listen(6789);
 })();


### PR DESCRIPTION
Jira issue: [WP-60](http://jira.webinos.org/browse/WP-60)

Quick fix (see commit fcb3f0af51019971288cb95703ce89d1699fd9c1). If we continue to use `connect` for this (with security checks added), multiple PZPs per machine should be supported.
