### PR TITLE
Enable platform building on windows using "npm install"

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,14 +5,16 @@
     'dependencies': [
       'webinos/common/manager/certificate_manager/binding.gyp:certificate_manager',
       'webinos/common/manager/policy_manager/src/binding.gyp:pm',
+      'webinos/common/manager/keystore/src/binding.gyp:keystore',
       'webinos/api/contacts/src/binding.gyp:localcontacts',
       'webinos/api/devicestatus/src/binding.gyp:devicestatus',
       'webinos_wrt#host',
+      'webinos/api/discovery/src/binding.gyp:bluetooth',
     ],
     'conditions': [ 
-      [ 'OS!="win"', {
-        'dependencies': [
-          'webinos/api/discovery/src/binding.gyp:bluetooth',
+      [ 'OS=="win"', {
+        'dependencies': [ # Prompt man is only implemented on windows
+            'webinos/common/manager/policy_manager/src/promptMan/binding.gyp:promptMan',
           ],
         },
       ],
@@ -26,6 +28,7 @@
       {
         'files': [
           'build/Release/certificate_manager.node',
+          'build/Release/keystore.node',
           'build/Release/localcontacts.node',
           'build/Release/bluetooth.node',
           'build/Release/nativedevicestatus.node',
@@ -33,6 +36,17 @@
         ],
         'destination': 'node_modules/',
       }],
+    'conditions': [ 
+        [ 'OS=="win"', {
+            'copies': [{
+                'files': [
+                    'build/Release/promptMan.node',
+            ],
+            'destination': 'node_modules/',
+            }],
+        },
+        ],
+    ],
     }, # end webinos_wrt
   ], 
 }

--- a/webinos/api/discovery/src/binding.gyp
+++ b/webinos/api/discovery/src/binding.gyp
@@ -12,6 +12,11 @@
           'cflags':['-std=gnu++0x'] ,
         },
         ],
+		[ 'OS=="win"', {
+		  'sources': [            
+			'bluetooth_NotImplemented.cc',
+		  ],
+        }]
       ],
     },
   ] # end targets

--- a/webinos/api/discovery/src/bluetooth_NotImplemented.cc
+++ b/webinos/api/discovery/src/bluetooth_NotImplemented.cc
@@ -1,0 +1,67 @@
+// TODO: Implement bluetooth on windows
+#include <v8.h>
+#include <node.h>
+
+using namespace node;
+using namespace v8;
+
+
+class BTDiscovery: ObjectWrap
+{
+  public:
+
+  static Persistent<FunctionTemplate> s_ct;
+
+  static void Init(Handle<Object> target)
+  {
+    HandleScope scope;
+
+    Local<FunctionTemplate> t = FunctionTemplate::New(New);
+
+    s_ct = Persistent<FunctionTemplate>::New(t);
+    s_ct->InstanceTemplate()->SetInternalFieldCount(1);
+    s_ct->SetClassName(String::NewSymbol("BT"));
+
+    NODE_SET_PROTOTYPE_METHOD(s_ct, "scan_device", Scan_device);
+
+    NODE_SET_PROTOTYPE_METHOD(s_ct, "file_transfer", File_transfer);
+    
+    target->Set(String::NewSymbol("bluetooth"), s_ct->GetFunction());
+  }
+
+  BTDiscovery()
+  {
+  }
+
+  ~BTDiscovery()
+  {
+  }
+
+  static Handle<Value> New(const Arguments& args)
+  {
+    HandleScope scope;
+    BTDiscovery* bd = new BTDiscovery();
+    bd->Wrap(args.This());
+    return args.This();
+  }
+
+  static Handle<Value> Scan_device(const Arguments& args)
+  {
+	throw "Not implemented yet";
+  }
+
+  static Handle<Value> File_transfer(const Arguments& args)
+  {
+    throw "Not implemented yet";
+  }
+};
+Persistent<FunctionTemplate> BTDiscovery::s_ct;
+
+extern "C" {
+  static void init (Handle<Object> target)
+  {
+	  BTDiscovery::Init(target);
+  }
+
+  NODE_MODULE(bluetooth, init);
+}

--- a/webinos/common/manager/keystore/src/binding.gyp
+++ b/webinos/common/manager/keystore/src/binding.gyp
@@ -22,7 +22,7 @@
         }],
         [ 'OS=="win"', {
 		  'sources': [            
-			'ksImpl_Win.cpp',
+			'ksImpl_NotImplemented.cpp',
 		  ],
         }],
 		[ 'OS=="linux"', {

--- a/webinos/common/manager/keystore/src/ksImpl_NotImplemented.cpp
+++ b/webinos/common/manager/keystore/src/ksImpl_NotImplemented.cpp
@@ -1,0 +1,25 @@
+#include "ksImpl.h"
+
+//TODO: Implement keystore
+
+
+int __get(const char * svc, void ** secret) throw(::KeyStoreException)
+{
+	throw ::KeyStoreException("Key store is not yet implemented");
+}
+
+void __put(const char * svc, void * secret) throw(::KeyStoreException)
+{
+	throw ::KeyStoreException("Key store is not yet implemented");
+}
+
+void __freeSecretResource(void * secret) throw(::KeyStoreException)
+{
+	throw ::KeyStoreException("Key store is not yet implemented");
+}
+
+void __delete(const char * svc) throw(::KeyStoreException)
+{
+	throw ::KeyStoreException("Key store is not yet implemented");
+}
+


### PR DESCRIPTION
All webinos native modules build on windows. Added dummy classes that throw "not implemented" exceptions for discover api and keystore manager on windows.

In response to http://jira.webinos.org/browse/WP-86

Things to do prior using "npm install" on windows:

Either Remove

"qrcode":"0.x.x",
"mdns": "0.x.x"

from package.json. qrcode depends on canvas which is being fixed and mdns requires Bonjour SDK. They are not hard constrains to run pzp and pzh.

Or install them manually following the instructions on the developer.webinos.org portal.
