### PR TITLE
Added engine minimum versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
     "connect": "2.x.x",
     "mdns": "0.x.x"
   },
+  "engines" : {
+    "node" : ">=0.6.18",
+    "npm" : ">= 1.1.17"
+  },
   "keywords": ["webinos", "api"],
-  "repository": "git://github.com/webinos",
+  "repository": "git://github.com/webinos/Webinos-Platform.git",
   "preferGlobal": true 
 }


### PR DESCRIPTION
Set minimum version of node to 0.6.18 and npm to 1.1.17 in order to support node-gyp.

Jira issue: [WP-82](http://jira.webinos.org/browse/WP-82)
