### PR TITLE
Fixed promptMan require statement

### DIFF
--- a/webinos/common/manager/policy_manager/lib/policymanager.js
+++ b/webinos/common/manager/policy_manager/lib/policymanager.js
@@ -42,7 +42,7 @@
 				console.log("policy manager could not be loaded");
 			}
 			if (os.platform()==='win32'){
-				this.promptMan = require('../src/promptMan/build/Release/promptMan.node');
+				this.promptMan = require('promptMan');
 			}
 		}
 		this.pmCore = new this.pmNativeLib.PolicyManagerInt();


### PR DESCRIPTION
There is no need to specify the exact location rather then .node name

Jira issue: WP-89
