### PR TITLE
Explicitely list the node modules to zip.

### DIFF
--- a/webinos/common/android/build.xml
+++ b/webinos/common/android/build.xml
@@ -8,8 +8,22 @@
 		<!-- Creates app/assets/webinos.zip -->
 		<zip destfile="${basedir}/webinos/common/android/app/assets/modules/webinos.zip">
 			<zipfileset dir="${basedir}" prefix="wp4" includes="
-			webinos_pzp.js,
-			node_modules/,
+				webinos_pzp.js,
+				node_modules/ansi/,
+				node_modules/connect/,
+				node_modules/crypt/,
+				node_modules/ejs/,
+				node_modules/jsormdb/,
+				node_modules/openid/,
+				node_modules/sax/,
+				node_modules/schema/,
+				node_modules/seq/,
+				node_modules/webinos/,
+				node_modules/websocket/,
+				node_modules/xml2js/,
+				node_modules/webinos/,
+				node_modules/expat2.js,
+				node_modules/xmldigsig.js,
 			webinos/" excludes="
 			webinos/common/android/,
 			webinos/pzh/,


### PR DESCRIPTION
Instead of including everything in node_modules into the zip file
that is included in the apk, just list the modules that are really
needed. Fixes including unwanted binary modules that were compiled
for a different arch.

http://jira.webinos.org/browse/WP-108
