### PR TITLE
Wp 84 seperate discovery and rpc

### DIFF
--- a/webinos/api/servicedisco/lib/rpc_servicedisco.js
+++ b/webinos/api/servicedisco/lib/rpc_servicedisco.js
@@ -1,28 +1,41 @@
 /*******************************************************************************
-*  Code contributed to the webinos project
-* 
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*  
-*     http://www.apache.org/licenses/LICENSE-2.0
-*  
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-* 
-* Copyright 2011 Alexander Futasz, Fraunhofer FOKUS
-******************************************************************************/
+ *  Code contributed to the webinos project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2011 Alexander Futasz, Fraunhofer FOKUS
+ ******************************************************************************/
 (function () {
+
+	var idCount = 0;
+
+	/**
+	 * Creates a new unique identifier to be used for RPC requests and responses.
+	 * @function
+	 * @private
+	 */
+	var getNextID = function(sessionId) {
+		if (idCount == Number.MAX_VALUE) idCount = 0;
+		idCount++;
+		return sessionId + idCount;
+	}
 
 	/**
 	 * Webinos ServiceDiscovery service constructor (server side).
 	 * @constructor
 	 * @param rpcHandler A handler for functions that use RPC to deliver their result.  
 	 */
-	function ServiceDiscoModule (rpcHandler) {
+	function Discovery(rpcHandler, params) {
 		// inherit from RPCWebinosService
 		this.base = RPCWebinosService;
 		this.base({
@@ -30,6 +43,44 @@
 			displayName: 'ServiceDiscovery',
 			description: 'Webinos ServiceDiscovery'
 		});
+
+		/**
+		 * Registry of registered RPC objects.
+		 */
+		this.registry = params[0];
+
+		/**
+		 * RPC handler
+		 */
+		this.rpcHandler = rpcHandler;
+
+		/**
+		 * Holds other Service objects, not registered here. Only used on the
+		 * PZH.
+		 */
+		this.remoteServiceObjects = [];
+
+		/**
+		 * Holds callbacks for findServices callbacks from the PZH
+		 */
+		this.remoteServicesFoundCallbacks = {};
+
+		if (typeof this.rpcHandler.parent !== 'undefined') {
+			var that = this;
+
+			// add listener to pzp object, to be called when remote services
+			// are returned by the pzh
+			this.rpcHandler.parent.addRemoteServiceListener(function (payload) {
+				var callback = that.remoteServicesFoundCallbacks[payload.id];
+
+				if (!callback) {
+					console.log("ServiceDiscovery: no findServices callback found for id: " + payload.id);
+					return;
+				}
+
+				callback(payload.message, payload.id);
+			});
+		}
 
 		/**
 		 * Call a listener for each found service.
@@ -44,27 +95,259 @@
 			var filter = params[2];
 
 			var callback;
-			rpcHandler.findServices(serviceType, callback, options, filter);
-			
+			search.call(this, serviceType, callback, options, filter);
+
 			function callback(services) {
 				services = services || [];
-				
+
 				function stripFuncs(el) {
 					return typeof el.getInformation === 'function' ? el.getInformation() : el; 
 				}
 				services = services.map(stripFuncs);
 
 				for (var i = 0; i < services.length; i++) {
-					console.log('rpc.findService: calling found callback for ' + services[i].id);
+					console.log('findServices: calling found callback for ' + services[i].id);
 					var rpc = rpcHandler.createRPC(objectRef, 'onservicefound', services[i]);
 					rpcHandler.executeRPC(rpc);
 				}
 			}
 		};
+
+		/**
+		 * Used by the ServiceDiscovery to search for registered services.
+		 * @param serviceType ServiceType object to search for.
+		 * @param callback Callback to call with results.
+		 * @param options Timeout, optional.
+		 * @param filter Filters based on location, name, description, optional.
+		 * @private
+		 * @function
+		 */
+		var search = function (serviceType, callback, options, filter) {
+			console.log('INFO: [Discovery] '+"search: searching for ServiceType: " + serviceType.api);
+			var results = [];
+			var cstar = serviceType.api.indexOf("*");
+			if(cstar !== -1){
+				//*c*
+				if(serviceType.api.lastIndexOf("*") !== 0){
+					var len = serviceType.api.length - 1;
+					var midString = serviceType.api.substring(1, len);
+					for (var i in this.registry.getRegisteredObjectsMap()){
+						if(i.indexOf(midString) != -1) {
+							for( var j = 0; j <this.registry.getRegisteredObjectsMap()[i].length; j++){
+								results.push(this.registry.getRegisteredObjectsMap()[i][j]);
+							}
+						}
+					}
+				}
+				//*, *c
+				else {
+					if(serviceType.api.length == 1) {
+						for (var i in this.registry.getRegisteredObjectsMap()){
+							for( var j = 0; j <this.registry.getRegisteredObjectsMap()[i].length;j++){
+								results.push(this.registry.getRegisteredObjectsMap()[i][j]);
+							}
+						}
+					}
+					else {
+						var restString = serviceType.api.substr(1);
+						for (var i in this.registry.getRegisteredObjectsMap()) {
+							if(i.indexOf(restString, i.length - restString.length) !== -1)	{
+								for( var j = 0; j <this.registry.getRegisteredObjectsMap()[i].length; j++){
+									results.push(this.registry.getRegisteredObjectsMap()[i][j]);
+								}
+							}
+						}
+					}
+				}
+				callback(results);
+
+			}
+			else {
+				function deliverResults(r) {
+					function isDuplicate(sv, pos) {
+						var cnt = 0;
+						for (var i=0; i<r.length; i++) {
+							if (sv.id === r[i].id & sv.serviceAddress === r[i].serviceAddress) {
+								if (i === pos && cnt === 0) {
+									return true;
+								}
+								cnt += 1;
+							}
+						}
+						return false;
+					}
+					r = r.filter(isDuplicate);
+
+					// filter results for zoneId
+					if (filter && typeof filter.zoneId === 'object') {
+						function hasZoneId(sv) {
+							for (var i=0; i<filter.zoneId.length; i++) {
+								var found = sv.serviceAddress.indexOf(filter.zoneId[i]) !== -1 ? true : false;
+								if (found) return true;
+							}
+							return false;
+						}
+						r = r.filter(hasZoneId);
+					}
+
+					// finally return results
+					callback(r);
+				}
+
+				for (var i in this.registry.getRegisteredObjectsMap()) {
+					if (i === serviceType.api) {
+						console.log('INFO: [Discovery] '+"search: found matching service(s) for ServiceType: " + serviceType.api);
+						results = this.registry.getRegisteredObjectsMap()[i];
+					}
+				}
+
+				// add address where this service is available, namely this pzp/pzh sessionid
+				for (var i=0; i<results.length; i++) {
+					results[i].serviceAddress = this.rpcHandler.sessionId; // This is source addres, it is used by messaging for returning back
+				}
+				var webinos_ = require('webinos')(__dirname);
+				var global = webinos_.global.require(webinos_.global.pzp.location,'lib/session').configuration;
+
+				// reference counter of all entities we expect services back from
+				// Not in peer mode and connected
+				var entityRefCount = (this.rpcHandler.parent.mode !== global.modes[2] && this.rpcHandler.parent.state === global.states[2])? 1 : 0; 
+				// Fetch from peers that are connected
+				if (this.rpcHandler.parent && this.rpcHandler.parent.config.type === "Pzp") {
+					if ((this.rpcHandler.parent.mode === global.modes[3] || this.rpcHandler.parent.mode === global.modes[2]) && this.rpcHandler.parent.state === global.states[2]) {
+						for (var key in this.rpcHandler.parent.connectedPzp) {
+							if (this.rpcHandler.parent.connectedPzp.hasOwnProperty(key)) {
+								if(this.rpcHandler.parent.connectedPzp[key].state === global.states[2]) {
+									entityRefCount += 1;
+								}
+							}
+						}
+					}
+				}
+				// no connection to a PZH & other connected Peers, don't ask for remote services
+				if (!this.rpcHandler.parent || entityRefCount === 0) {
+					deliverResults(results);
+					return;
+				}
+
+				var callbackId = getNextID(this.rpcHandler.sessionId);
+				var that = this;
+
+				// deliver results once timeout kicks in
+				setTimeout(function() {
+					if (that.remoteServicesFoundCallbacks[callbackId]) {
+						that.remoteServicesFoundCallbacks[callbackId]([], callbackId, true);
+					}
+				}, options && typeof options.timeout !== 'undefined' ? options.timeout : 120000); // default: 120 secs
+
+				// store callback in map for lookup on returned remote results
+				this.remoteServicesFoundCallbacks[callbackId] = (function(res, refCnt) {
+					return function(remoteServices, cId, ignoreCnt) {
+
+						function isServiceType(el) {
+							return el.api === serviceType.api ? true : false;
+						}
+						res = res.concat(remoteServices.filter(isServiceType));
+						refCnt -= 1;
+
+						if (refCnt < 1 || ignoreCnt) {
+							// entity reference counter is zero, got all answers, so continue
+							deliverResults(res);
+							delete that.remoteServicesFoundCallbacks[cId];
+						}
+					}
+				})(results, entityRefCount);
+
+				if (this.rpcHandler.parent && this.rpcHandler.parent.config.type === "Pzp") {
+					// ask for remote service objects
+					if (this.rpcHandler.parent.mode !== global.modes[2] && this.rpcHandler.parent.state === global.states[2]) { // Not in peer mode & connected
+						this.rpcHandler.parent.prepMsg(this.rpcHandler.sessionId, this.rpcHandler.parent.config.pzhId, 'findServices', {id: callbackId});
+					}
+
+					if ((this.rpcHandler.parent.mode === global.modes[3] || this.rpcHandler.parent.mode === global.modes[2]) &&
+							this.rpcHandler.parent.state === global.states[2]) {
+						for (var key in this.rpcHandler.parent.connectedPzp) { //
+							if (this.rpcHandler.parent.connectedPzp.hasOwnProperty(key) && key !== this.rpcHandler.sessionId) {
+								if(this.rpcHandler.parent.connectedPzp[key].state === global.states[2]) {
+									this.rpcHandler.parent.prepMsg(this.rpcHandler.sessionId, key, 'findServices', {id: callbackId});
+								}
+							}
+						}
+					}
+				}
+			}
+		};
 	}
 
-	ServiceDiscoModule.prototype = new RPCWebinosService;
+	Discovery.prototype = new RPCWebinosService;
 
-	exports.Service = ServiceDiscoModule;
+	/**
+	 * Add services to internal array. Used by PZH.
+	 * @param services Array of services to be added.
+	 */
+	Discovery.prototype.addRemoteServiceObjects = function(services) {
+		console.log('INFO: [Discovery] '+"addRemoteServiceObjects: found " + (services && services.length) || 0 + " services.");
+		this.remoteServiceObjects = this.remoteServiceObjects.concat(services);
+	};
+
+	/**
+	 * Remove services from internal array. Used by PZH.
+	 * @param address Remove all services for this address.
+	 */
+	Discovery.prototype.removeRemoteServiceObjects = function(address) {
+		var oldCount = this.remoteServiceObjects.length;
+
+		function isNotServiceFromAddress(element) {
+			return address !== element.serviceAddress;
+		}
+
+		this.remoteServiceObjects = this.remoteServiceObjects.filter(isNotServiceFromAddress);
+
+		var removedCount = oldCount - this.remoteServiceObjects.length;
+		console.log("removeRemoteServiceObjects: removed " + removedCount + " services from: " + address);
+	};
+
+	/**
+	 * Get an array of all registered Service objects.
+	 * @returns Array with said objects.
+	 * @private
+	 */
+	Discovery.prototype.getRegisteredServices = function() {
+		var that = this;
+		var results = [];
+
+		for (var service in this.registry.getRegisteredObjectsMap()) {
+			results = results.concat(this.registry.getRegisteredObjectsMap()[service]);
+		}
+
+		function getServiceInfo(el) {
+			el = el.getInformation();
+			el.serviceAddress = that.rpcHandler.sessionId;
+			return el;
+		}
+		return results.map(getServiceInfo);
+	};
+
+	/**
+	 * Get an array of all known services, including local and remote
+	 * services. Used by PZH.
+	 * @param exceptAddress Address of services that match will be excluded from
+	 * results.
+	 * @returns Array with known services.
+	 * @private
+	 */
+	Discovery.prototype.getAllServices = function(exceptAddress) {
+		var results = [];
+
+		function isNotExceptAddress(el) {
+			return (el.serviceAddress !== exceptAddress) ? true : false;
+		}
+		results = this.remoteServiceObjects.filter(isNotExceptAddress);
+
+		results = results.concat(this.getRegisteredServices());
+
+		return results;
+	};
+
+	exports.Service = Discovery;
 
 })();

--- a/webinos/common/rpc/lib/rpc.js
+++ b/webinos/common/rpc/lib/rpc.js
@@ -22,15 +22,13 @@
 	if (typeof webinos === 'undefined')
 		webinos = {};
 
-	if (typeof module === 'undefined')
+	if (typeof module === 'undefined') {
 		var exports = {};
-	else
-		var exports = module.exports = {};
-
-	if (typeof module !== 'undefined')
-		var utils = require('./webinos.utils.js');
-	else
 		var utils = webinos.utils || (webinos.utils = {});
+	} else {
+		var utils = require('./webinos.utils.js');
+		var exports = module.exports = {};
+	}
 
 	var sessionId = "";
 	var idCount = 0;
@@ -773,7 +771,7 @@
 	 * @constructor
 	 * @param obj Object with fields describing the service.
 	 */
-	this.RPCWebinosService = function (obj) {
+	RPCWebinosService = function (obj) {
 		if (!obj) {
 			this.id = '';
 			this.api = '';
@@ -793,7 +791,7 @@
 	 * Get an information object from the service.
 	 * @returns Object including id, api, displayName, serviceAddress.
 	 */
-	this.RPCWebinosService.prototype.getInformation = function () {
+	RPCWebinosService.prototype.getInformation = function () {
 		return {
 			id: this.id,
 			api: this.api,
@@ -808,7 +806,7 @@
 	 * @constructor
 	 * @param api String with API URI.
 	 */
-	this.ServiceType = function(api) {
+	ServiceType = function(api) {
 		if (!api)
 			throw new Error('ServiceType: missing argument: api');
 
@@ -868,5 +866,7 @@
 	} else {
 		// export for web browser
 		this.RPCHandler = _RPCHandler;
+		this.RPCWebinosService = RPCWebinosService;
+		this.ServiceType = ServiceType;
 	}
 })();

--- a/webinos/common/rpc/lib/rpc.js
+++ b/webinos/common/rpc/lib/rpc.js
@@ -65,38 +65,14 @@
 
 		/**
 		 * Used to store objectRefs for callbacks that get invoked more than once
-		 * Holds other Service objects, not registered here. Only used on the
-		 * PZH.
 		 */
 		this.objRefCacheTable = {};
-		this.remoteServiceObjects = [];
 
 		/**
 		 * Used on the client side by executeRPC to store callbacks that are
 		 * invoked once the RPC finished.
-		 * Holds callbacks for findServices callbacks from the PZH
 		 */
 		this.awaitingResponse = {};
-		this.remoteServicesFoundCallbacks = {};
-
-		if (typeof this.parent !== 'undefined') {
-			var that = this;
-
-			// add listener to pzp object, to be called when remote services
-			// are returned by the pzh
-			this.parent.addRemoteServiceListener(function (payload) {
-				var callback = that.remoteServicesFoundCallbacks[payload.id];
-
-				if (!callback) {
-					console.log("ServiceDiscovery: no findServices callback found for id: " + payload.id);
-					return;
-				}
-
-				callback(payload.message, payload.id);
-			});
-		}
-
-		this.requesterMapping = [];
 
 		this.messageHandler = {
 				write: function() {
@@ -234,7 +210,6 @@
 
 			// callback registration (one request to many responses)
 			if (typeof request.fromObjectRef !== 'undefined' && request.fromObjectRef != null) {
-				this.requesterMapping[request.fromObjectRef] = from;
 				this.objRefCacheTable[request.fromObjectRef] = {'from':from, msgId: msgid};
 				fromObjectRef = request.fromObjectRef;
 			}
@@ -450,235 +425,6 @@
 	 */
 	_RPCHandler.prototype.registerCallbackObject = function (callback) {
 		this.registry.registerCallbackObject(callback);
-
-	/**
-	 * Used by the ServiceDiscovery to search for registered services.
-	 * @param serviceType ServiceType object to search for.
-	 * @param callback Callback to call with results.
-	 * @param options Timeout, optional.
-	 * @param filter Filters based on location, name, description, optional.
-	 * @private
-	 */
-	_RPCHandler.prototype.findServices = function (serviceType, callback, options, filter) {
-		console.log('INFO: [RPC] '+"findService: searching for ServiceType: " + serviceType.api);
-		var results = [];
-		var cstar = serviceType.api.indexOf("*");
-		if(cstar !== -1){
-			//*c*
-			if(serviceType.api.lastIndexOf("*") !== 0){
-				var len = serviceType.api.length - 1;
-				var midString = serviceType.api.substring(1, len);
-				for (var i in this.objects){
-					if(i.indexOf(midString) != -1) {
-						for( var j = 0; j <this.objects[i].length; j++){
-							results.push(this.objects[i][j]);
-						}
-					}
-				}
-			}
-			//*, *c
-			else {
-				if(serviceType.api.length == 1) {
-					for (var i in this.objects){
-						for( var j = 0; j <this.objects[i].length;j++){
-							results.push(this.objects[i][j]);
-						}
-					}
-				}
-				else {
-					var restString = serviceType.api.substr(1);
-					for (var i in this.objects) {
-						if(i.indexOf(restString, i.length - restString.length) !== -1)	{
-							for( var j = 0; j <this.objects[i].length; j++){
-								results.push(this.objects[i][j]);
-							}
-						}
-					}
-				}
-			}
-			callback(results);
-
-		}
-		else {
-		   function deliverResults(r) {
-				function isDuplicate(sv, pos) {
-					var cnt = 0;
-					for (var i=0; i<r.length; i++) {
-						if (sv.id === r[i].id & sv.serviceAddress === r[i].serviceAddress) {
-							if (i === pos && cnt === 0) {
-								return true;
-							}
-							cnt += 1;
-						}
-					}
-					return false;
-				}
-				r = r.filter(isDuplicate);
-
-				// filter results for zoneId
-				if (filter && typeof filter.zoneId === 'object') {
-					function hasZoneId(sv) {
-						for (var i=0; i<filter.zoneId.length; i++) {
-							var found = sv.serviceAddress.indexOf(filter.zoneId[i]) !== -1 ? true : false;
-							if (found) return true;
-						}
-						return false;
-					}
-					r = r.filter(hasZoneId);
-				}
-
-				// finally return results
-				callback(r);
-			}
-
-			for (var i in this.objects) {
-				if (i === serviceType.api) {
-					console.log('INFO: [RPC] '+"findService: found matching service(s) for ServiceType: " + serviceType.api);
-					results = this.objects[i];
-				}
-			}
-
-			// add address where this service is available, namely this pzp/pzh sessionid
-			for (var i=0; i<results.length; i++) {
-				results[i].serviceAddress = sessionId; // This is source addres, it is used by messaging for returning back
-			}
-			var webinos_ = require('webinos')(__dirname);
-			var global = webinos_.global.require(webinos_.global.pzp.location,'lib/session').configuration;
-			
-			// reference counter of all entities we expect services back from
-			// Not in peer mode and connected
-			var entityRefCount = (this.parent.mode !== global.modes[2] && this.parent.state === global.states[2])? 1 : 0; 
-			// Fetch from peers that are connected
-			if (this.parent && this.parent.config.type === "Pzp") {
-				if ((this.parent.mode === global.modes[3] || this.parent.mode === global.modes[2]) && this.parent.state === global.states[2]) {
-					for (var key in this.parent.connectedPzp) {
-						if (this.parent.connectedPzp.hasOwnProperty(key)) {
-							if(this.parent.connectedPzp[key].state === global.states[2]) {
-								entityRefCount += 1;
-							}
-						}
-					}
-				}
-			}
-			// no connection to a PZH & other connected Peers, don't ask for remote services
-			if (!this.parent || entityRefCount === 0) {
-				deliverResults(results);
-				return;
-			}
-
-			var callbackId = getNextID();
-			var that = this;
-
-			// deliver results once timeout kicks in
-			setTimeout(function() {
-				if (that.remoteServicesFoundCallbacks[callbackId]) {
-					that.remoteServicesFoundCallbacks[callbackId]([], callbackId, true);
-				}
-			}, options && typeof options.timeout !== 'undefined' ? options.timeout : 120000); // default: 120 secs
-
-			// store callback in map for lookup on returned remote results
-			this.remoteServicesFoundCallbacks[callbackId] = (function(res, refCnt) {
-				return function(remoteServices, cId, ignoreCnt) {
-
-					function isServiceType(el) {
-						return el.api === serviceType.api ? true : false;
-					}
-					res = res.concat(remoteServices.filter(isServiceType));
-					refCnt -= 1;
-
-					if (refCnt < 1 || ignoreCnt) {
-						// entity reference counter is zero, got all answers, so continue
-						deliverResults(res);
-						delete that.remoteServicesFoundCallbacks[cId];
-					}
-				}
-			})(results, entityRefCount);
-
-			if (this.parent && this.parent.config.type === "Pzp") {
-				// ask for remote service objects
-				if (this.parent.mode !== global.modes[2] && this.parent.state === global.states[2]) { // Not in peer mode & connected
-					this.parent.prepMsg(this.parent.sessionId, this.parent.config.pzhId, 'findServices', {id: callbackId});
-				}
-
-				if ((this.parent.mode === global.modes[3] || this.parent.mode === global.modes[2]) && 
-						this.parent.state === global.states[2]) {
-					for (var key in this.parent.connectedPzp) { //
-						if (this.parent.connectedPzp.hasOwnProperty(key) && key !== this.parent.sessionId) {
-							if(this.parent.connectedPzp[key].state === global.states[2]) {
-								this.parent.prepMsg(this.parent.sessionId, key, 'findServices', {id: callbackId});
-							}
-						}
-					}
-				}
-			}
-		}
-	};
-
-	/**
-	 * Add services to internal array. Used by PZH.
-	 * @param services Array of services to be added.
-	 */
-	_RPCHandler.prototype.addRemoteServiceObjects = function(services) {
-		console.log('INFO: [RPC] '+"addRemoteServiceObjects: found " + (services && services.length) || 0 + " services.");
-		this.remoteServiceObjects = this.remoteServiceObjects.concat(services);
-	};
-
-	/**
-	 * Remove services from internal array. Used by PZH.
-	 * @param address Remove all services for this address.
-	 */
-	_RPCHandler.prototype.removeRemoteServiceObjects = function(address) {
-		var oldCount = this.remoteServiceObjects.length;
-
-		function isNotServiceFromAddress(element) {
-			return address !== element.serviceAddress;
-		}
-
-		this.remoteServiceObjects = this.remoteServiceObjects.filter(isNotServiceFromAddress);
-
-		var removedCount = oldCount - this.remoteServiceObjects.length;
-		console.log("removeRemoteServiceObjects: removed " + removedCount + " services from: " + address);
-	};
-
-	/**
-	 * Get an array of all known services, including local and remote
-	 * services. Used by PZH.
-	 * @param exceptAddress Address of services that match will be excluded from
-	 * results.
-	 * @returns Array with known services.
-	 * @private
-	 */
-	_RPCHandler.prototype.getAllServices = function(exceptAddress) {
-		var results = [];
-
-		function isNotExceptAddress(el) {
-			return (el.serviceAddress !== exceptAddress) ? true : false;
-		}
-		results = this.remoteServiceObjects.filter(isNotExceptAddress);
-
-		results = results.concat(this.getRegisteredServices());
-
-		return results;
-	};
-
-	/**
-	 * Get an array of all registered Service objects.
-	 * @returns Array with said objects.
-	 * @private
-	 */
-	_RPCHandler.prototype.getRegisteredServices = function() {
-		var results = [];
-
-		for (var service in this.objects) {
-			results = results.concat(this.objects[service]);
-		}
-
-		function getServiceInfo(el) {
-			el = el.getInformation();
-			el.serviceAddress = sessionId;
-			return el;
-		}
-		return results.map(getServiceInfo);
 	};
 
 	/**

--- a/webinos/common/rpc/lib/rpc.js
+++ b/webinos/common/rpc/lib/rpc.js
@@ -518,7 +518,11 @@
 			var filteredRO = receiverObjs.filter(function(el, idx, array) {
 				return el.id !== callback.id;
 			});
-			this.objects[callback.api] = filteredRO;
+			if (filteredRO.length > 0) {
+				this.objects[callback.api] = filteredRO;
+			} else {
+				delete this.objects[callback.api];
+			}
 		}
 	};
 

--- a/webinos/common/rpc/test/jasmine/rpc.spec.js
+++ b/webinos/common/rpc/test/jasmine/rpc.spec.js
@@ -19,76 +19,79 @@
 describe('common.RPC', function() {
 	var webinos = require('webinos')(__dirname);
 
+	var Registry = webinos.global.require(webinos.global.rpc.location, "lib/registry").Registry;
+	var registry;
 	var RPCHandler = webinos.global.require(webinos.global.rpc.location).RPCHandler;
 	var rpcHandler;
 
 	beforeEach(function() {
-		rpcHandler = new RPCHandler();
+		registry = new Registry();
+		rpcHandler = new RPCHandler(undefined, registry);
 	});
 
-	it('RPCHandler is exported from node module', function() {
-		expect(RPCHandler).toEqual(jasmine.any(Function));
-	});
+	describe('rpcHandler', function() {
 
-	it('RPCHandler object instantiated', function() {
-		expect(rpcHandler).toBeDefined();
-	});
+		it('RPCHandler is exported from node module', function() {
+			expect(RPCHandler).toEqual(jasmine.any(Function));
+		});
 
-	it('has createRPC function', function() {
-		expect(rpcHandler.createRPC).toEqual(jasmine.any(Function));
-	});
+		it('RPCHandler object instantiated', function() {
+			expect(rpcHandler).toBeDefined();
+		});
 
-	it('has executeRPC function', function() {
-		expect(rpcHandler.executeRPC).toEqual(jasmine.any(Function));
-	});
+		it('has createRPC function', function() {
+			expect(rpcHandler.createRPC).toEqual(jasmine.any(Function));
+		});
 
-	it('has registerObject function', function() {
-		expect(rpcHandler.registerObject).toEqual(jasmine.any(Function));
-	});
+		it('has executeRPC function', function() {
+			expect(rpcHandler.executeRPC).toEqual(jasmine.any(Function));
+		});
 
-	it('has unregisterObject function', function() {
-		expect(rpcHandler.unregisterObject).toEqual(jasmine.any(Function));
-	});
+		it('has registerCallbackObject function', function() {
+			expect(rpcHandler.registerCallbackObject).toEqual(jasmine.any(Function));
+		});
 
-	it('has registerCallbackObject function', function() {
-		expect(rpcHandler.registerCallbackObject).toEqual(jasmine.any(Function));
-	});
+		it('has registerCallbackObject function', function() {
+			expect(rpcHandler.registerCallbackObject).toEqual(jasmine.any(Function));
+		});
 
-	it('createRPC with service as string type', function() {
-		var rpc = rpcHandler.createRPC('Service', 'functionName', [1]);
-		expect(rpc).toEqual(jasmine.any(Object));
+		it('createRPC with service as string type', function() {
+			var rpc = rpcHandler.createRPC('Service', 'functionName', [1]);
+			expect(rpc).toEqual(jasmine.any(Object));
 
-		expect(rpc.jsonrpc).toBeDefined();
-		expect(rpc.jsonrpc).toEqual('2.0');
+			expect(rpc.jsonrpc).toBeDefined();
+			expect(rpc.jsonrpc).toEqual('2.0');
 
-		expect(rpc.id).toBeDefined();
-		expect(rpc.id).toEqual(jasmine.any(String));
+			expect(rpc.id).toBeDefined();
+			expect(rpc.id).toEqual(jasmine.any(String));
 
-		expect(rpc.method).toBeDefined();
-		expect(rpc.method).toEqual(jasmine.any(String));
+			expect(rpc.method).toBeDefined();
+			expect(rpc.method).toEqual(jasmine.any(String));
 
-		expect(rpc.params).toBeDefined();
-		expect(rpc.params).toEqual(jasmine.any(Object));
-	});
+			expect(rpc.params).toBeDefined();
+			expect(rpc.params).toEqual(jasmine.any(Object));
+		});
 
-	it('createRPC with service as RPCWebinosService', function() {
-		var service = new RPCWebinosService();
-		var rpc = rpcHandler.createRPC(service, 'functionName', [1]);
-		expect(rpc).toEqual(jasmine.any(Object));
+		it('createRPC with service as RPCWebinosService', function() {
+			var service = new RPCWebinosService();
+			var rpc = rpcHandler.createRPC(service, 'functionName', [1]);
+			expect(rpc).toEqual(jasmine.any(Object));
 
-		expect(rpc.jsonrpc).toBeDefined();
-		expect(rpc.jsonrpc).toEqual('2.0');
+			expect(rpc.jsonrpc).toBeDefined();
+			expect(rpc.jsonrpc).toEqual('2.0');
 
-		expect(rpc.id).toBeDefined();
-		expect(rpc.id).toEqual(jasmine.any(String));
+			expect(rpc.id).toBeDefined();
+			expect(rpc.id).toEqual(jasmine.any(String));
 
-		expect(rpc.method).toBeDefined();
-		expect(rpc.method).toEqual(jasmine.any(String));
+			expect(rpc.method).toBeDefined();
+			expect(rpc.method).toEqual(jasmine.any(String));
 
-		expect(rpc.serviceAddress).toBeDefined();
+			expect(rpc.serviceAddress).toBeDefined();
 
-		expect(rpc.params).toBeDefined();
-		expect(rpc.params).toEqual(jasmine.any(Object));
+			expect(rpc.params).toBeDefined();
+			expect(rpc.params).toEqual(jasmine.any(Object));
+		});
+
 	});
 
 	describe('RPC service registration', function() {
@@ -103,19 +106,31 @@ describe('common.RPC', function() {
 			rpc = rpcHandler.createRPC(service, 'functionName', [1]);
 		});
 
+		it('Registry is exported from node module', function() {
+			expect(Registry).toEqual(jasmine.any(Function));
+		});
+
+		it('has registerObject function', function() {
+			expect(registry.registerObject).toEqual(jasmine.any(Function));
+		});
+
+		it('has unregisterObject function', function() {
+			expect(registry.unregisterObject).toEqual(jasmine.any(Function));
+		});
+
 		it('has no registered services initially', function() {
-			expect(Object.keys(rpcHandler.objects).length).toEqual(0);
+			expect(Object.keys(registry.objects).length).toEqual(0);
 		});
 
 		it('has exactly one registered service after registering', function() {
-			rpcHandler.registerObject(service);
-			expect(Object.keys(rpcHandler.objects).length).toEqual(1);
+			registry.registerObject(service);
+			expect(Object.keys(registry.objects).length).toEqual(1);
 		});
 
 		it('has no registered services after unregistering', function() {
-			rpcHandler.registerObject(service);
-			rpcHandler.unregisterObject(service);
-			expect(Object.keys(rpcHandler.objects).length).toEqual(0);
+			registry.registerObject(service);
+			registry.unregisterObject(service);
+			expect(Object.keys(registry.objects).length).toEqual(0);
 		});
 	});
 
@@ -146,7 +161,7 @@ describe('common.RPC', function() {
 				error();
 			};
 			service = new MockService();
-			rpcHandler.registerObject(service);
+			registry.registerObject(service);
 
 			// use our own message handler write function, usually this would
 			// write the request out to the remote peer

--- a/webinos/common/rpc/test/jasmine/rpc.spec.js
+++ b/webinos/common/rpc/test/jasmine/rpc.spec.js
@@ -1,90 +1,146 @@
+/*******************************************************************************
+ *  Code contributed to the webinos project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2011 Alexander Futasz, Fraunhofer FOKUS
+ ******************************************************************************/
+
 describe('common.RPC', function() {
 	var webinos = require('webinos')(__dirname);
-	
+
 	var RPCHandler = webinos.global.require(webinos.global.rpc.location).RPCHandler;
-	
+	var rpcHandler;
+
 	beforeEach(function() {
-		this.addMatchers({
-			toBeFunction: function() {
-				return typeof this.actual === 'function';
-			},
-			toBeObject: function() {
-				return typeof this.actual === 'object';
-			},
-			toBeString: function() {
-				return typeof this.actual === 'string';
-			},
-			toBeNumber: function() {
-				return typeof this.actual === 'number';
-			}
-		});
+		rpcHandler = new RPCHandler();
 	});
 
 	it('RPCHandler is exported from node module', function() {
-		expect(RPCHandler).toBeFunction();
+		expect(RPCHandler).toEqual(jasmine.any(Function));
 	});
-	
-	var rpcHandler = new RPCHandler();
 
 	it('RPCHandler object instantiated', function() {
 		expect(rpcHandler).toBeDefined();
 	});
 
 	it('has createRPC function', function() {
-		expect(rpcHandler.createRPC).toBeFunction();
+		expect(rpcHandler.createRPC).toEqual(jasmine.any(Function));
 	});
 
 	it('has executeRPC function', function() {
-		expect(rpcHandler.executeRPC).toBeFunction();
+		expect(rpcHandler.executeRPC).toEqual(jasmine.any(Function));
 	});
-	
+
 	it('has registerObject function', function() {
-		expect(rpcHandler.registerObject).toBeFunction();
+		expect(rpcHandler.registerObject).toEqual(jasmine.any(Function));
 	});
-	
+
 	it('has unregisterObject function', function() {
-		expect(rpcHandler.unregisterObject).toBeFunction();
+		expect(rpcHandler.unregisterObject).toEqual(jasmine.any(Function));
 	});
-	
+
 	it('has registerCallbackObject function', function() {
-		expect(rpcHandler.registerCallbackObject).toBeFunction();
+		expect(rpcHandler.registerCallbackObject).toEqual(jasmine.any(Function));
 	});
-	
+
 	it('createRPC with service as string type', function() {
 		var rpc = rpcHandler.createRPC('Service', 'functionName', [1]);
-		expect(rpc).toBeObject();
-		
+		expect(rpc).toEqual(jasmine.any(Object));
+
 		expect(rpc.jsonrpc).toBeDefined();
 		expect(rpc.jsonrpc).toEqual('2.0');
-		
+
 		expect(rpc.id).toBeDefined();
-		expect(rpc.id).toBeNumber();
-		
+		expect(rpc.id).toEqual(jasmine.any(String));
+
 		expect(rpc.method).toBeDefined();
-		expect(rpc.method).toBeString();
-		
+		expect(rpc.method).toEqual(jasmine.any(String));
+
 		expect(rpc.params).toBeDefined();
-		expect(rpc.params).toBeObject();
+		expect(rpc.params).toEqual(jasmine.any(Object));
 	});
-	
+
 	it('createRPC with service as RPCWebinosService', function() {
 		var service = new RPCWebinosService();
 		var rpc = rpcHandler.createRPC(service, 'functionName', [1]);
-		expect(rpc).toBeObject();
-		
+		expect(rpc).toEqual(jasmine.any(Object));
+
 		expect(rpc.jsonrpc).toBeDefined();
 		expect(rpc.jsonrpc).toEqual('2.0');
-		
+
 		expect(rpc.id).toBeDefined();
-		expect(rpc.id).toBeNumber();
-		
+		expect(rpc.id).toEqual(jasmine.any(String));
+
 		expect(rpc.method).toBeDefined();
-		expect(rpc.method).toBeString();
-		
+		expect(rpc.method).toEqual(jasmine.any(String));
+
 		expect(rpc.serviceAddress).toBeDefined();
-		
+
 		expect(rpc.params).toBeDefined();
-		expect(rpc.params).toBeObject();
+		expect(rpc.params).toEqual(jasmine.any(Object));
 	});
-	
+
+	describe('RPC service registration', function() {
+		var service;
+		var rpc;
+
+		this.beforeEach(function() {
+			service = new RPCWebinosService();
+			service.api = 'prop-api';
+			service.displayName = 'prop-displayName';
+			service.description = 'prop-description';
+			rpc = rpcHandler.createRPC(service, 'functionName', [1]);
+		});
+
+		it('has no registered services initially', function() {
+			expect(Object.keys(rpcHandler.objects).length).toEqual(0);
+		});
+
+		it('has exactly one registered service after registering', function() {
+			rpcHandler.registerObject(service);
+			expect(Object.keys(rpcHandler.objects).length).toEqual(1);
+		});
+
+		it('has no registered services after unregistering', function() {
+			rpcHandler.registerObject(service);
+			rpcHandler.unregisterObject(service);
+			expect(Object.keys(rpcHandler.objects).length).toEqual(0);
+		});
+	});
+
+	it('can execute and handle RPC', function() {
+		var service = new RPCWebinosService();
+		service.api = 'prop-api';
+		service.displayName = 'prop-displayName';
+		service.description = 'prop-description';
+		var rpc = rpcHandler.createRPC(service, 'functionName', [1]);
+		rpcHandler.registerObject(service);
+
+		var msgHandler = {
+				write: function() {
+					rpcHandler.handleMessage(rpc);
+				}
+		};
+		rpcHandler.setMessageHandler(msgHandler);
+		spyOn(rpcHandler, 'handleMessage')
+
+		rpcHandler.executeRPC(rpc);
+		expect(rpcHandler.handleMessage).toHaveBeenCalled();
+		expect(rpcHandler.handleMessage.mostRecentCall.args.length).toEqual(1);
+		expect(rpcHandler.handleMessage.mostRecentCall.args[0].method).toBeDefined();
+		expect(rpcHandler.handleMessage.mostRecentCall.args[0].id).toBeDefined();
+		expect(rpcHandler.handleMessage.mostRecentCall.args[0].params).toBeDefined();
+	});
+
 });

--- a/webinos/pzh/lib/pzh_farm.js
+++ b/webinos/pzh/lib/pzh_farm.js
@@ -112,7 +112,7 @@ farm.startFarm = function (url, name, callback) {
                 var removed = session.common.removeClient(cl, conn);
                 if (removed !== null && typeof removed !== "undefined"){
                   cl.messageHandler.removeRoute(removed, conn.servername);
-                  cl.rpcHandler.removeRemoteServiceObjects(removed);
+                  cl.discovery.removeRemoteServiceObjects(removed);
                 }
               }
             } catch (err) {

--- a/webinos/pzh/lib/pzh_sessionHandling.js
+++ b/webinos/pzh/lib/pzh_sessionHandling.js
@@ -59,8 +59,8 @@ var Pzh = function (modules) {
   this.connectedPzp = {};/** Holds connected PZP information such as IP address and socket connection */
   this.registry     = new Registry();
   this.rpcHandler   = new RPCHandler(undefined, this.registry); // Handler for remote method calls.
+  this.registry.loadModules(modules, this.rpcHandler); // load specified modules
   this.messageHandler = new MessageHandler(this.rpcHandler);// handler of all things message
-  this.rpcHandler.loadModules(modules);// load specified modules
   this.expecting;    // Set by authcode directly
 };
 

--- a/webinos/pzh/lib/pzh_sessionHandling.js
+++ b/webinos/pzh/lib/pzh_sessionHandling.js
@@ -38,6 +38,7 @@ if (typeof exports !== "undefined") {
     var log            = new session.common.debug("pzh_session");
     var rpc            = webinos.global.require(webinos.global.rpc.location);
     var Registry       = webinos.global.require(webinos.global.rpc.location, "lib/registry").Registry;
+    var Discovery      = webinos.global.require(webinos.global.api.service_discovery.location, "lib/rpc_servicedisco").Service;
     var MessageHandler = webinos.global.require(webinos.global.manager.messaging.location, "lib/messagehandler").MessageHandler;
     var RPCHandler     = rpc.RPCHandler;
     var authcode       = require("./pzh_authcode");
@@ -59,6 +60,8 @@ var Pzh = function (modules) {
   this.connectedPzp = {};/** Holds connected PZP information such as IP address and socket connection */
   this.registry     = new Registry();
   this.rpcHandler   = new RPCHandler(undefined, this.registry); // Handler for remote method calls.
+  this.discovery    = new Discovery(this.rpcHandler, [this.registry]);
+  this.registry.registerObject(this.discovery);
   this.registry.loadModules(modules, this.rpcHandler); // load specified modules
   this.messageHandler = new MessageHandler(this.rpcHandler);// handler of all things message
   this.expecting;    // Set by authcode directly
@@ -320,12 +323,12 @@ Pzh.prototype.processMsg = function(conn, msgObj) {
     // information sent by connecting PZP about services it supports. These details are then used by findServices 
     else if(validMsgObj.type === "prop" && validMsgObj.payload.status === "registerServices") {
       log.info("receiving Webinos services from pzp...");
-      self.rpcHandler.addRemoteServiceObjects(validMsgObj.payload.message);
+      this.discovery.addRemoteServiceObjects(validMsgObj.payload.message);
     }   
     // Send findServices information to connected PZP..
     else if(validMsgObj.type === "prop" && validMsgObj.payload.status === "findServices") {
       log.info("trying to send webinos services from this RPC handler to " + validMsgObj.from + "...");
-      var services = self.rpcHandler.getAllServices(validMsgObj.from);
+      var services = this.discovery.getAllServices(validMsgObj.from);
       var msg = self.prepMsg(self.sessionId, validMsgObj.from, "foundServices", services);
       msg.payload.id = validMsgObj.payload.message.id;
       self.sendMessage(msg, validMsgObj.from);

--- a/webinos/pzh/lib/pzh_sessionHandling.js
+++ b/webinos/pzh/lib/pzh_sessionHandling.js
@@ -36,7 +36,8 @@ if (typeof exports !== "undefined") {
     var webinos        = require("webinos")(__dirname);
     var session        = webinos.global.require(webinos.global.pzp.location, "lib/session");
     var log            = new session.common.debug("pzh_session");
-    var rpc            = webinos.global.require(webinos.global.rpc.location, "lib/rpc");
+    var rpc            = webinos.global.require(webinos.global.rpc.location);
+    var Registry       = webinos.global.require(webinos.global.rpc.location, "lib/registry").Registry;
     var MessageHandler = webinos.global.require(webinos.global.manager.messaging.location, "lib/messagehandler").MessageHandler;
     var RPCHandler     = rpc.RPCHandler;
     var authcode       = require("./pzh_authcode");
@@ -56,7 +57,8 @@ var Pzh = function (modules) {
   this.config       = {};/** Holds PZH Configuration particularly certificates */
   this.connectedPzh = {};/** Holds Connected PZH information such as IP address, port and socket */
   this.connectedPzp = {};/** Holds connected PZP information such as IP address and socket connection */
-  this.rpcHandler = new RPCHandler();// Handler for remote method calls.
+  this.registry     = new Registry();
+  this.rpcHandler   = new RPCHandler(undefined, this.registry); // Handler for remote method calls.
   this.messageHandler = new MessageHandler(this.rpcHandler);// handler of all things message
   this.rpcHandler.loadModules(modules);// load specified modules
   this.expecting;    // Set by authcode directly

--- a/webinos/pzp/lib/pzp_peerTLSClient.js
+++ b/webinos/pzp/lib/pzp_peerTLSClient.js
@@ -74,7 +74,7 @@ PzpClient.prototype.connectOtherPZP = function (parent, msg) {
               parent.serviceListener && parent.serviceListener(validMsgObj.payload);
             } else if(validMsgObj.type === "prop" && validMsgObj.payload.status === "findServices") {
                 log.info("trying to send Webinos Services from this RPC handler to " + validMsgObj.from + "...");
-                var services = parent.rpcHandler.getAllServices(validMsgObj.from);
+                var services = parent.discovery.getAllServices(validMsgObj.from);
                 var msg = {"type":"prop", "from":parent.sessionId, "to":validMsgObj.from, "payload":{"status":"foundServices", "message":services}};
                 msg.payload.id = validMsgObj.payload.message.id;
                 parent.sendMessage(msg, validMsgObj.from);

--- a/webinos/pzp/lib/pzp_peerTLSServer.js
+++ b/webinos/pzp/lib/pzp_peerTLSServer.js
@@ -82,7 +82,7 @@ PzpServer.prototype.startServer = function (parent, callback) {
             session.common.processedMsg(self, obj, function(validMsgObj) {
               if(validMsgObj.type === "prop" && validMsgObj.payload.status === "findServices") {
                 log.info("trying to send Webinos Services from this RPC handler to " + validMsgObj.from + "...");
-                var services = parent.rpcHandler.getAllServices(validMsgObj.from);
+                var services = parent.discovery.getAllServices(validMsgObj.from);
                 var msg = {"type":"prop", "from":parent.sessionId, "to":validMsgObj.from, "payload":{"status":"foundServices", "message":services}};
                 msg.payload.id = validMsgObj.payload.message.id;
                 parent.sendMessage(msg, validMsgObj.from);

--- a/webinos/pzp/lib/pzp_sessionHandling.js
+++ b/webinos/pzp/lib/pzp_sessionHandling.js
@@ -37,7 +37,8 @@ var webinos       = require("webinos")(__dirname);
 var session       = require("./session");
 var log           = new session.common.debug("pzp_session");
 var global        = session.configuration
-var rpc           = webinos.global.require(webinos.global.rpc.location, "lib/rpc");
+var rpc           = webinos.global.require(webinos.global.rpc.location);
+var Registry      = webinos.global.require(webinos.global.rpc.location, "lib/registry").Registry;
 
 var MessageHandler = webinos.global.require(webinos.global.manager.messaging.location, "lib/messagehandler").MessageHandler;
 var RPCHandler     = rpc.RPCHandler;
@@ -528,7 +529,8 @@ Pzp.prototype.processMsg = function(msgObj, callback) {
 
 Pzp.prototype.initializePzp = function(config, modules, callback) {
   var self = this;
-  self.rpcHandler     = new RPCHandler(this); // Handler for remote method calls.
+  self.registry       = new Registry();
+  self.rpcHandler     = new RPCHandler(this, self.registry); // Handler for remote method calls.
   self.messageHandler = new MessageHandler(this.rpcHandler); // handler for all things message
   self.modules        = modules;
   self.inputConfig    = config;

--- a/webinos/pzp/lib/pzp_sessionHandling.js
+++ b/webinos/pzp/lib/pzp_sessionHandling.js
@@ -531,10 +531,10 @@ Pzp.prototype.initializePzp = function(config, modules, callback) {
   var self = this;
   self.registry       = new Registry();
   self.rpcHandler     = new RPCHandler(this, self.registry); // Handler for remote method calls.
+  self.registry.loadModules(modules, self.rpcHandler); // load specified modules
   self.messageHandler = new MessageHandler(this.rpcHandler); // handler for all things message
   self.modules        = modules;
   self.inputConfig    = config;
-  self.rpcHandler.loadModules(modules);// load specified modules
   
   
   global.createDirectoryStructure( function() {

--- a/webinos/pzp/lib/pzp_sessionHandling.js
+++ b/webinos/pzp/lib/pzp_sessionHandling.js
@@ -39,6 +39,7 @@ var log           = new session.common.debug("pzp_session");
 var global        = session.configuration
 var rpc           = webinos.global.require(webinos.global.rpc.location);
 var Registry      = webinos.global.require(webinos.global.rpc.location, "lib/registry").Registry;
+var Discovery     = webinos.global.require(webinos.global.api.service_discovery.location, "lib/rpc_servicedisco").Service;
 
 var MessageHandler = webinos.global.require(webinos.global.manager.messaging.location, "lib/messagehandler").MessageHandler;
 var RPCHandler     = rpc.RPCHandler;
@@ -232,7 +233,7 @@ Pzp.prototype.authenticated = function(cn, instance, callback) {
     var msg = self.messageHandler.registerSender(self.sessionId, self.config.pzhId);
     self.sendMessage(msg, self.config.pzhId);
 
-    var localServices = self.rpcHandler.getRegisteredServices();
+    var localServices = self.discovery.getRegisteredServices();
     self.prepMsg(self.sessionId, self.config.pzhId, "registerServices", localServices);
     log.info("sent msg to register local services with pzh");
     if (self.pzptlsServerState !== global.states[2]) {
@@ -531,6 +532,8 @@ Pzp.prototype.initializePzp = function(config, modules, callback) {
   var self = this;
   self.registry       = new Registry();
   self.rpcHandler     = new RPCHandler(this, self.registry); // Handler for remote method calls.
+  self.discovery      = new Discovery(self.rpcHandler, [self.registry]);
+  self.registry.registerObject(self.discovery);
   self.registry.loadModules(modules, self.rpcHandler); // load specified modules
   self.messageHandler = new MessageHandler(this.rpcHandler); // handler for all things message
   self.modules        = modules;

--- a/webinos/test/build.xml
+++ b/webinos/test/build.xml
@@ -10,6 +10,7 @@
     	<!-- Available compilation levels: advanced, simple, whitespace -->
         <jscompiler compilationlevel="whitespace" prettyPrint="true" output="${basedir}/client/webinos.js">
             <sources dir="${basedir}/../">
+                <file name="common/rpc/lib/registry.js"/>
                 <file name="common/rpc/lib/rpc.js"/>
             	<file name="common/manager/messaging/lib/messagehandler.js"/>
    		<file name="wrt/lib/webinos.session.js"/>

--- a/webinos/wrt/lib/webinos.js
+++ b/webinos/wrt/lib/webinos.js
@@ -63,7 +63,7 @@
 
     if (typeof webinos === 'undefined') webinos = {};
 
-    webinos.rpcHandler = new RPCHandler();
+    webinos.rpcHandler = new RPCHandler(undefined, new Registry());
     webinos.messageHandler = new MessageHandler(webinos.rpcHandler);
     webinos.discovery = new ServiceDiscovery(webinos.rpcHandler);
     webinos.ServiceDiscovery = webinos.discovery; // for backward compat


### PR DESCRIPTION
Move discovery related functions from RPC module to existing service discovery API module. Move registry related functions from RPC module to new registry module. Registry is used by both, RPC and discovery.

Note that these changes are based on https://github.com/webinos/Webinos-Platform/pull/82
which is why the commits from that pull request are here as well.

http://jira.webinos.org/browse/WP-84
