### PR TITLE
Fix some of compilation warnings for the PZP

### DIFF
--- a/webinos/api/devicestatus/src/aspects/platform/linux/battery.cc
+++ b/webinos/api/devicestatus/src/aspects/platform/linux/battery.cc
@@ -44,6 +44,8 @@ string Battery::getPropertyValue(string * property, string * component)
 
 	if (*property == "batteryBeingCharged")
 		return batteryBeingCharged(*component);
+	// TODO: instead trigger the error callback with DOMError of type InvalidAccessError (or abort if no error callback defined)
+	return "Invalid property";
 }
 
 string Battery::batteryLevel(string batteryName)

--- a/webinos/api/devicestatus/src/aspects/platform/win/battery.cc
+++ b/webinos/api/devicestatus/src/aspects/platform/win/battery.cc
@@ -47,7 +47,7 @@ string Battery::getPropertyValue(string * property, string * component)
 
 	if (*property == "batteryBeingCharged")
 		return batteryBeingCharged(*component);
-	
+	// TODO: instead trigger the error callback with DOMError of type InvalidAccessError (or abort if no error callback defined)	
 	return "Invalid property";
 }
 

--- a/webinos/api/devicestatus/src/nativedevicestatus.cc
+++ b/webinos/api/devicestatus/src/nativedevicestatus.cc
@@ -45,7 +45,7 @@ namespace nativedevicestatus_v8 {
 
 			vector<string> components = aspect->getComponents();
 			
-			for (int i=0; i < components.size(); i++) {
+			for (unsigned int i=0; i < components.size(); i++) {
 				array->Set(i, String::New(components[i].c_str(), components[i].length()));
 			}
 

--- a/webinos/common/manager/policy_manager/src/core/common.cpp
+++ b/webinos/common/manager/policy_manager/src/core/common.cpp
@@ -62,7 +62,7 @@ const bool compare_regexp(const string& target,const string& expression) {
 string glob2regexp (const string& glob) {
     string result = "";
 //    cout << "\n Converting " << glob << " with size " << glob.size();
-    for (int i = 0;i<glob.size();++i)
+    for (unsigned int i = 0;i<glob.size();++i)
     {
 	if (glob[i]=='?')
 	    result+=".";

--- a/webinos/common/manager/policy_manager/src/core/policymanager/Condition.cpp
+++ b/webinos/common/manager/policy_manager/src/core/policymanager/Condition.cpp
@@ -25,7 +25,7 @@ Condition::Condition(TiXmlElement* condition){
 		combine = (strcmp(condition->Attribute("combine"),"or")==0) ? OR : AND;
 	else
 		combine = AND;
-	int iii=0;
+	//int iii=0;
 	int num_match = 0;
 	for(TiXmlNode * node = (TiXmlNode*)condition->FirstChild(); node;
 			node = (TiXmlNode*)node->NextSibling() ) {
@@ -43,7 +43,7 @@ Condition::Condition(TiXmlElement* condition){
 			string tmp = (child->Attribute("match")!=NULL) ? child->Attribute ("match") : "";
 			if (tmp.length() == 0)
 				tmp = (child->GetText() != NULL) ? child->GetText() : "";
-			int nextPos, pos = 0;
+			unsigned int nextPos, pos = 0;
 		
 			//LOG("[Policy]  : match value: id"<<++iii);	
 			while(pos < tmp.length())
@@ -55,7 +55,7 @@ Condition::Condition(TiXmlElement* condition){
 					nextPos = tmp.length();			
 				if(pos != nextPos){
 					string attr = child->Attribute("attr");
-					int dot_pos = attr.find(".");
+					unsigned int dot_pos = attr.find(".");
 					string key = (dot_pos != string::npos) ? attr.substr(0, dot_pos) : attr;
 					
 					match_info_str * tmp_info = new match_info_str();
@@ -95,7 +95,7 @@ ConditionResponse Condition::evaluate(Request * req){
 	
 	if (combine==AND)
 	{
-		for (int i=0; i<conditions.size(); i++)
+		for (unsigned int i=0; i<conditions.size(); i++)
 		{
 			tmpCR = conditions[i]->evaluate(req);
 			LOGD("[SUB-COND EVAL AND] %d ",tmpCR);
@@ -135,7 +135,7 @@ ConditionResponse Condition::evaluate(Request * req){
 	}
 	else if (combine==OR)
 	{
-		for (int i=0; i<conditions.size(); i++)
+		for (unsigned int i=0; i<conditions.size(); i++)
 		{
 			tmpCR = conditions[i]->evaluate(req);
 			LOGD("[COND EVAL OR] %d", tmpCR);
@@ -162,13 +162,13 @@ ConditionResponse Condition::evaluate(Request * req){
 		else
 			return NO_MATCH;
 	}	
+	// TODO: is that right? What should happen if policy invalid?
+	return NOT_DETERMINED;
 }
 
 ConditionResponse Condition::evaluateEnvironment(Request* req){	
 	vector<match_info_str*> my_environment_params;
 	map<string, string> requestEnvironment_attrs = req->getEnvironmentAttrs();
-	bool found;
-	ConditionResponse tmp;
 	
 	map<string,vector<match_info_str*> >::iterator it;
 	match_info_str * my_roaming = (it = environment_attrs.find("roaming"))!=environment_attrs.end() 
@@ -191,7 +191,7 @@ ConditionResponse Condition::evaluateEnvironment(Request* req){
 			LOGD("[ENVIRONMENT] my_roaming null");
 		
 		string req_bearer = requestEnvironment_attrs["bearer-type"];
-		for(int j=0; j<my_bearer_vet.size(); j++){
+		for(unsigned int j=0; j<my_bearer_vet.size(); j++){
 			if(equals(req_bearer, my_bearer_vet[j]->value, string2strcmp_mode(my_bearer_vet[j]->equal_func)))
 				return MATCH;
 		}
@@ -210,7 +210,7 @@ ConditionResponse Condition::evaluateEnvironment(Request* req){
 			LOGD("[ENVIRONMENT] my_roaming null");
 		
 		string req_bearer = requestEnvironment_attrs["bearer-type"];
-		for(int j=0; j<my_bearer_vet.size(); j++){
+		for(unsigned int j=0; j<my_bearer_vet.size(); j++){
 			if(!equals(req_bearer, my_bearer_vet[j]->value, string2strcmp_mode(my_bearer_vet[j]->equal_func)))
 				return NO_MATCH;
 		}
@@ -237,9 +237,9 @@ ConditionResponse Condition::evaluateFeatures(Request* req){
 
 	if(combine == AND){
 		// find any No Match
-		for(int j=0; req_features && j<my_features.size(); j++){
+		for(unsigned int j=0; req_features && j<my_features.size(); j++){
 			found = false;
-			for(int i=0; i<req_features->size(); i++){
+			for(unsigned int i=0; i<req_features->size(); i++){
 				string mod_function = my_features[j]->mod_func;
 				string s = (mod_function != "") 
 							? modFunction(mod_function, req_features->at(i))
@@ -260,8 +260,8 @@ ConditionResponse Condition::evaluateFeatures(Request* req){
 	}
 	else if(combine == OR){
 		// find any Match
-		for(int j=0; req_features && j<my_features.size(); j++){
-			for(int i=0; i<req_features->size(); i++){
+		for(unsigned int j=0; req_features && j<my_features.size(); j++){
+			for(unsigned int i=0; i<req_features->size(); i++){
 				string mod_function = my_features[j]->mod_func;
 				string s = (mod_function != "") 
 							? modFunction(mod_function, req_features->at(i))
@@ -275,6 +275,8 @@ ConditionResponse Condition::evaluateFeatures(Request* req){
 		else
 			return NO_MATCH;
 	}
+	// TODO: is that right? What should happen if policy is invalid?
+	return NOT_DETERMINED;
 }
 
 ConditionResponse Condition::evaluateCapabilities(Request* req){
@@ -317,10 +319,10 @@ ConditionResponse Condition::evaluateCapabilities(Request* req){
 	if(combine == AND){
 		// find any No Match
 		LOGD("my_capabilities_params.size() %d",my_capabilities_params.size());
-		for(int j=0; j<my_capabilities_params.size(); j++){
+		for(unsigned int j=0; j<my_capabilities_params.size(); j++){
 			found = false;
 			LOGD("req_capabilities_params->size() %d",req_capabilities_params->size());
-			for(int i=0; i<req_capabilities_params->size(); i++){
+			for(unsigned int i=0; i<req_capabilities_params->size(); i++){
 				string mod_function = my_capabilities_params[j]->mod_func;
 				string s = (mod_function != "") 
 							? modFunction(mod_function, req_capabilities_params->at(i))
@@ -347,8 +349,8 @@ ConditionResponse Condition::evaluateCapabilities(Request* req){
 	}
 	else if(combine == OR){
 	// find any Match
-		for(int j=0; j<my_capabilities_params.size(); j++){
-			for(int i=0; i<req_capabilities_params->size(); i++){
+		for(unsigned int j=0; j<my_capabilities_params.size(); j++){
+			for(unsigned int i=0; i<req_capabilities_params->size(); i++){
 				string mod_function = my_capabilities_params[j]->mod_func;
 				string s = (mod_function != "") 
 							? modFunction(mod_function, req_capabilities_params->at(i))
@@ -367,4 +369,6 @@ ConditionResponse Condition::evaluateCapabilities(Request* req){
 		else
 			return NO_MATCH;
 	}
+	// TODO: is that right? What should happen if policy is invalid?
+	return NOT_DETERMINED;
 }

--- a/webinos/common/manager/policy_manager/src/core/policymanager/Globals.cpp
+++ b/webinos/common/manager/policy_manager/src/core/policymanager/Globals.cpp
@@ -22,9 +22,9 @@
 
 string modFunction(const string& func, const string& val){
 	// func = {scheme, host, authority, scheme-authority, path}
-	int pos = val.find(":");
-	int pos1 = val.find_last_of("/",pos+2);
-	int pos2 = val.find("/",pos1+1);
+	unsigned int pos = val.find(":");
+	unsigned int pos1 = val.find_last_of("/",pos+2);
+	unsigned int pos2 = val.find("/",pos1+1);
 	
 	if(func == "scheme"){
 		if(pos != string::npos)
@@ -35,8 +35,8 @@ string modFunction(const string& func, const string& val){
 		if(func == "authority")
 			return authority;
 		else{
-			int pos_at = authority.find("@")+1;
-			int pos3 = authority.find(":");
+			unsigned int pos_at = authority.find("@")+1;
+			unsigned int pos3 = authority.find(":");
 			if(pos_at == string::npos)
 				pos_at = 0;
 			if(pos3 == string::npos)

--- a/webinos/common/manager/policy_manager/src/core/policymanager/Policy.cpp
+++ b/webinos/common/manager/policy_manager/src/core/policymanager/Policy.cpp
@@ -59,7 +59,7 @@ bool Policy::matchSubject(Request* req){
 		return true;		// Policy is valid for all widget
 	}
 	else
-		for(int i=0; i<subjects.size(); i++){
+		for(unsigned int i=0; i<subjects.size(); i++){
 			if(subjects[i]->match(req)){
 				return true;
 			}
@@ -85,7 +85,7 @@ Effect Policy::evaluate(Request* req){
 		if(ruleCombiningAlgorithm == deny_overrides_algorithm){
 			LOGD("[Policy::evaluate] deny_overrides algorithm");
 			int effects_result[] = {0,0,0,0,0,0,0};
-			for(int i=0; i<rules.size(); i++){
+			for(unsigned int i=0; i<rules.size(); i++){
 				int tmp = rules[i]->evaluate(req);
 				LOGD("eval : %d",tmp);
 				effects_result[tmp]++;
@@ -114,7 +114,7 @@ Effect Policy::evaluate(Request* req){
 		else if(ruleCombiningAlgorithm == permit_overrides_algorithm){
 			LOGD("[Policy::evaluate] permit_overrides algorithm");
 			int effects_result[] = {0,0,0,0,0,0,0};
-			for(int i=0; i<rules.size(); i++){
+			for(unsigned int i=0; i<rules.size(); i++){
 				effects_result[rules[i]->evaluate(req)]++;
 				if(effects_result[PERMIT] > 0)
 					return PERMIT;
@@ -142,7 +142,7 @@ Effect Policy::evaluate(Request* req){
 		else if(ruleCombiningAlgorithm == first_applicable_algorithm){
 			LOGD("[Policy] first_applicable algorithm");
 			Effect tmp_effect;
-			for(int i=0; i<rules.size(); i++){
+			for(unsigned int i=0; i<rules.size(); i++){
 				tmp_effect = rules[i]->evaluate(req);
 				if(tmp_effect != UNDETERMINED && tmp_effect != INAPPLICABLE)
 					return tmp_effect;
@@ -153,6 +153,9 @@ Effect Policy::evaluate(Request* req){
 			}
 			return INAPPLICABLE;
 		}
+		else
+		  // TODO: is that right? what should happen with unknown values?
+		  return UNDETERMINED;
 	}
 	else
 		return INAPPLICABLE;

--- a/webinos/common/manager/policy_manager/src/core/policymanager/PolicySet.cpp
+++ b/webinos/common/manager/policy_manager/src/core/policymanager/PolicySet.cpp
@@ -76,7 +76,7 @@ bool PolicySet::matchSubject(Request* req){
 	if(subjects.size() == 0)
 		return true;
 	else
-		for(int i=0; i<subjects.size(); i++){
+		for(unsigned int i=0; i<subjects.size(); i++){
 			if(subjects[i]->match(req))
 				return true;
 		}
@@ -85,7 +85,7 @@ bool PolicySet::matchSubject(Request* req){
 
 Effect PolicySet::evaluatePolicies(Request * req){
 	
-	for(int i=0; i<policies.size(); i++){
+	for(unsigned int i=0; i<policies.size(); i++){
 			LOGD("policies[%d] = %s",i,policies[i]->description.data());
 	}
 	
@@ -96,7 +96,7 @@ Effect PolicySet::evaluatePolicies(Request * req){
 	if(policyCombiningAlgorithm == deny_overrides_algorithm){
 		LOGD("[PolicySet] deny_overrides algorithm");
 		int effects_result[] = {0,0,0,0,0,0,0};
-		for(int i=0; i<sortArray.size(); i++){
+		for(unsigned int i=0; i<sortArray.size(); i++){
 			effects_result[sortArray[i]->evaluate(req)]++;
 			if(effects_result[DENY] > 0)
 				return DENY;
@@ -139,7 +139,7 @@ Effect PolicySet::evaluatePolicies(Request * req){
 		LOGD("[PolicySet] permit_overrides algorithm");
 		int effects_result[] = {0,0,0,0,0,0,0};
 		
-		for(int i=0; i<sortArray.size(); i++){
+		for(unsigned int i=0; i<sortArray.size(); i++){
 			effects_result[sortArray[i]->evaluate(req)]++;
 			if(effects_result[PERMIT] > 0)
 				return PERMIT;
@@ -172,7 +172,7 @@ Effect PolicySet::evaluatePolicies(Request * req){
 	}
 	else if(policyCombiningAlgorithm == first_matching_target_algorithm){
 		LOGD("[PolicySet] first_matching_target algorithm");
-		for(int i=0; i<sortArray.size(); i++){
+		for(unsigned int i=0; i<sortArray.size(); i++){
 			LOGD("[PolicySet] try eval %s",sortArray[i]->description.data());
 			if(sortArray[i]->matchSubject(req)){
 				LOGD("[PolicySet] eval %s",sortArray[i]->description.data());

--- a/webinos/common/manager/policy_manager/src/core/policymanager/Request.cpp
+++ b/webinos/common/manager/policy_manager/src/core/policymanager/Request.cpp
@@ -85,7 +85,7 @@ TiXmlElement* Request::getXmlSubjectTag(){
 	for(map<string,vector<string>*>::iterator it=subject_attrs.begin(); it!=subject_attrs.end(); it++)
 	{
 		tmp = it->second;
-		for(int i=0; i<tmp->size(); i++){
+		for(unsigned int i=0; i<tmp->size(); i++){
 			attribute = new TiXmlElement("Attribute");
 			attributeValue = new TiXmlElement("AttributeValue");
 			attribute->SetAttribute("AttributeId", it->first);
@@ -106,7 +106,7 @@ TiXmlElement* Request::getXmlResourcesTag(){
 	vector<string>* tmp;
 	for(map<string,vector<string>*>::iterator it=resource_attrs.begin(); it!=resource_attrs.end(); it++){
 		tmp = it->second;
-		for(int i=0; i<tmp->size(); i++){
+		for(unsigned int i=0; i<tmp->size(); i++){
 			attribute = new TiXmlElement("Attribute");
 			attributeValue = new TiXmlElement("AttributeValue");
 			attribute->SetAttribute("AttributeId", it->first);

--- a/webinos/common/manager/policy_manager/src/core/policymanager/Subject.cpp
+++ b/webinos/common/manager/policy_manager/src/core/policymanager/Subject.cpp
@@ -29,7 +29,7 @@ Subject::Subject(TiXmlElement* subject){
 		if (tmp.length() == 0)
 			tmp = (child->GetText() != NULL) ? child->GetText() : "";
 		
-		int nextPos, pos = 0;
+		unsigned int nextPos, pos = 0;
 		while(pos < tmp.length())
 		{
 			nextPos = tmp.find(" ",pos);
@@ -37,7 +37,7 @@ Subject::Subject(TiXmlElement* subject){
 				nextPos = tmp.length();			
 			if(pos != nextPos){
 				string attr = child->Attribute("attr");
-				int dot_pos = attr.find(".");
+				unsigned int dot_pos = attr.find(".");
 				string key = (dot_pos != string::npos) ? attr.substr(0, dot_pos) : attr;
 				match_info_str * tmp_info = new match_info_str();
 				tmp_info->equal_func = (child->Attribute("func")!=NULL) ? child->Attribute("func") : "glob";
@@ -70,9 +70,9 @@ bool Subject::match(Request* req){
 		if(req->getSubjectAttrs().find(it_policy->first) != req->getSubjectAttrs().end()){
 			vector<string>* req_vet = req->getSubjectAttrs()[it_policy->first];
 			vector<match_info_str*> info_vet = it_policy->second;		
-			for(int j=0;j<info_vet.size(); j++){ //iteration on all policy's elements
+			for(unsigned int j=0;j<info_vet.size(); j++){ //iteration on all policy's elements
 				foundInBag = false;
-				for(int i=0; !foundInBag && i<req_vet->size(); i++){ //iteration on request's elements. 
+				for(unsigned int i=0; !foundInBag && i<req_vet->size(); i++){ //iteration on request's elements. 
 					string mod_function = info_vet[j]->mod_func;
 					string s = (mod_function != "") 
 						? modFunction(mod_function, req_vet->at(i))


### PR DESCRIPTION
Cf http://jira.webinos.org/browse/WP-131

After the patch, the warnings are down to 
In file included from ../webinos/api/contacts/src/thunderbird_AB_parser/MorkAddressBook.h:22:0,
                 from ../webinos/api/contacts/src/thunderbird_AB_parser/MorkAddressBook.cpp:19:
../webinos/api/contacts/contrib/MorkParser.h:16:0: warning: ignoring #pragma warning  [-Wunknown-pragmas]
In file included from ../webinos/api/contacts/contrib/MorkParser.cpp:13:0:
../webinos/api/contacts/contrib/MorkParser.h:16:0: warning: ignoring #pragma warning  [-Wunknown-pragmas]
../webinos/api/contacts/contrib/MorkParser.cpp: In member function 'bool MorkParser::parseCell()':
../webinos/api/contacts/contrib/MorkParser.cpp:254:7: warning: variable 'bColumnOid' set but not used [-Wunused-but-set-variable]
In file included from ../webinos/api/contacts/src/thunderbird_AB_parser/MorkAddressBook.h:22:0,
                 from ../webinos/api/contacts/src/thunderbird_AB_parser/node_contacts_mork.h:28,
                 from ../webinos/api/contacts/src/thunderbird_AB_parser/node_contacts_mork.cpp:19:
../webinos/api/contacts/contrib/MorkParser.h:16:0: warning: ignoring #pragma warning  [-Wunknown-pragmas]
../webinos/api/discovery/src/bluetooth.cc: In static member function 'static v8::Handlev8::Value BTDiscovery::Scan_device(const v8::Arguments&)':
../webinos/api/discovery/src/bluetooth.cc:128:19: warning: variable 'result' set but not used [-Wunused-but-set-variable]
../webinos/api/discovery/src/bluetooth.cc:144:9: warning: variable 'err' set but not used [-Wunused-but-set-variable]
../webinos/api/discovery/src/bluetooth.cc: In static member function 'static v8::Handlev8::Value BTDiscovery::File_transfer(const v8::Arguments&)':
../webinos/api/discovery/src/bluetooth.cc:317:19: warning: variable 'result' set but not used [-Wunused-but-set-variable]
../webinos/common/manager/policy_manager/src/core/policymanager/Globals.cpp: In function 'std::string modFunction(const string&, const string&)':
../webinos/common/manager/policy_manager/src/core/policymanager/Globals.cpp:54:22: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
