### PR TITLE
Wp 135 add tests for applauncher n discovery

### DIFF
--- a/webinos/api/applauncher/lib/applauncher.js
+++ b/webinos/api/applauncher/lib/applauncher.js
@@ -13,16 +13,17 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 * 
-* Copyright 2012 André Paul, Fraunhofer FOKUS
+* Copyright 2012 AndrÃ© Paul, Fraunhofer FOKUS
 ******************************************************************************/
 (function() {
+	var exec = require('child_process').exec;
 
 	/**
 	 * Webinos AppLauncher service constructor (server side).
 	 * @constructor
 	 * @param rpcHandler A handler for functions that use RPC to deliver their result.  
 	 */
-	var WebinosAppLauncherModule = function(rpcHandler) {
+	var WebinosAppLauncherModule = function(rpcHandler, params) {
 		// inherit from RPCWebinosService
 		this.base = RPCWebinosService;
 		this.base({
@@ -30,8 +31,28 @@
 			displayName:'AppLauncher API',
 			description:'The AppLauncher API for starting applications.'
 		});
+
+		this.browserExecPath = undefined;
+		if (params.browserExecPath) {
+			this.browserExecPath = params.browserExecPath;
+
+		} else {
+			var that = this;
+			if (process.platform === 'win32') {
+				exec('reg query HKCR\\http\\shell\\open\\command -ve', function(err, stdout, stderr) {
+					if (err) return;
+
+					that.browserExecPath = stdout.split('\r\n')[2].split('    ')[3];
+					if (/--/.test(that.browserExecPath)) {
+						that.browserExecPath = that.browserExecPath.split('--')[0];
+					}
+				});
+			} else if (process.platform === 'linux') {
+				this.browserExecPath = 'xdg-open';
+			}
+		}
 	};
-	
+
 	WebinosAppLauncherModule.prototype = new RPCWebinosService;
 
 	/**
@@ -44,32 +65,28 @@
 	WebinosAppLauncherModule.prototype.launchApplication = function (params, successCB, errorCB, objectRef){
 		console.log("launchApplication was invoked. AppID: " +  params.applicationID + " Parameters: " + params.params);
 		
-		var startUpLine = params.applicationID;
-		
-		var i;
-		if (typeof params.params !== 'undefined'){
-			for (i = 0; i < params.params.length; i++){
-				startUpLine = startUpLine + " " + params.params[i];
+		if (!/^http[s]?:\/{2}/.test(params.applicationID) || !this.browserExecPath) {
+			console.log("applauncher: only http[s] AppIds are allowed or no browser available.");
+			if (typeof errorCB === "function") {
+				errorCB();
 			}
+			return;
 		}
 		
-		console.log("AppLauncher trying to launch: " + startUpLine);
+		var cmdLine = this.browserExecPath.concat(' ', params.applicationID);
+		console.log("AppLauncher trying to launch: " + cmdLine);
 		
-		var exec = require('child_process').exec;
-		exec(startUpLine, function callback(error, stdout, stderr){
-		    console.log("Result: " + error + " " + stdout + " " + stderr);
-		    
-		    if (error != null){
-		    	errorCB();
-		    }
-		    else {
-		    	successCB();
-		    } 
-		    	
-		});
-		
-	};
+		exec(cmdLine, function(error, stdout, stderr){
+			console.log("Result: " + error + " " + stdout + " " + stderr);
 
+			if (error && typeof errorCB === "function") {
+				errorCB();
+				return;
+			}
+
+			successCB();
+		});
+	};
 	
 	/**
 	 * Determine whether an app is available.
@@ -78,8 +95,8 @@
 	 */
 	WebinosAppLauncherModule.prototype.appInstalled = function (params, successCB, errorCB, objectRef){
 		console.log("appInstalled was invoked");
+		errorCB();
 	};
-
 
 	exports.Service = WebinosAppLauncherModule;
 

--- a/webinos/api/applauncher/test/jasmine/applauncher.spec.js
+++ b/webinos/api/applauncher/test/jasmine/applauncher.spec.js
@@ -1,49 +1,44 @@
 describe('api.applauncher', function() {
 
 	var webinos = require('webinos')(__dirname);
-	
-	var RPCHandler = webinos.global.require(webinos.global.rpc.location).RPCHandler;
-	var service = webinos.global.require(webinos.global.api.applauncher.location).Service;
-	var applauncher = new service(RPCHandler);
+
+	// make sure RPCWebinosService is defined as it is needed by applauncher.js
+	webinos.global.require(webinos.global.rpc.location).RPCHandler;
+	var WebinosAppLauncher = webinos.global.require(webinos.global.api.applauncher.location).Service;
+
+	var applauncher;
+
 	beforeEach(function() {
-		this.addMatchers({
-			toBeFunction: function() {
-				return typeof this.actual === 'function';
-			},
-			toBeObject: function() {
-				return typeof this.actual === 'object';
-			},
-			toBeString: function() {
-				return typeof this.actual === 'string';
-			},
-			toBeNumber: function() {
-				return typeof this.actual === 'number';
-			}
-		});
+		applauncher = new WebinosAppLauncher(undefined, {});
 	});
-	
-	it('Applauncher has funtion launchApplication', function() {
-		expect(applauncher.launchApplication).toBeFunction();
+
+	it('has funtion launchApplication', function() {
+		expect(applauncher.launchApplication).toEqual(jasmine.any(Function));
 	});
-	
-	
-	it('Applauncher has funtion appInstalled', function() {
-		expect(applauncher.appInstalled).toBeFunction();
+
+	it('has funtion appInstalled', function() {
+		expect(applauncher.appInstalled).toEqual(jasmine.any(Function));
 	});
-	
-	
-	it('Applauncher api equals http://webinos.org/api/applauncher', function() {
+
+	it('api property has right ServiceType', function() {
 		expect(applauncher.api).toEqual('http://webinos.org/api/applauncher');
 	});
-	
-	it('Applauncher displayName is string', function() {
-		expect(applauncher.displayName).toBeString();
+
+	it('displayName property is string', function() {
+		expect(applauncher.displayName).toEqual(jasmine.any(String));
 	});
-	
-	it('Applauncher description is string', function() {
-		expect(applauncher.description).toBeString();
+
+	it('description property is string', function() {
+		expect(applauncher.description).toEqual(jasmine.any(String));
 	});
-	
-	
-	
+
+	it('can launch the default web browser', function() {
+		waitsFor(function() {
+			return !!applauncher.browserExecPath;
+		});
+
+		runs(function() {
+			expect(applauncher.browserExecPath).toBeDefined();
+		})
+	});
 });

--- a/webinos/test/SpecRunner.html
+++ b/webinos/test/SpecRunner.html
@@ -13,6 +13,7 @@
   <script type="text/javascript" src="client/webinos.js"></script>
 
   <!-- include spec files here... -->
+  <script type="text/javascript" src="spec/DiscoverySpec.js"></script>
   <script type="text/javascript" src="spec/EventsSpec.js"></script>
   <script type="text/javascript" src="spec/ApplauncherSpec.js"></script>
 

--- a/webinos/test/SpecRunner.html
+++ b/webinos/test/SpecRunner.html
@@ -14,6 +14,7 @@
 
   <!-- include spec files here... -->
   <script type="text/javascript" src="spec/EventsSpec.js"></script>
+  <script type="text/javascript" src="spec/ApplauncherSpec.js"></script>
 
   <script type="text/javascript">
     (function() {

--- a/webinos/test/client/applauncher/index.html
+++ b/webinos/test/client/applauncher/index.html
@@ -111,11 +111,11 @@
 			</div><p>
 				<div>
 				AppID
-				<textarea id="textOut" rows="1" cols="60">C:\Users\apa\AppData\Local\Google\Chrome\Application\chrome.exe</textarea>
+				<textarea id="textOut" rows="1" cols="60">http://www.webinos.org/</textarea>
 				</div>
 				<div>
 				Param
-				<textarea id="textOutParam" rows="1" cols="60">www.webinos.org --kiosk --new-window</textarea>
+				<textarea id="textOutParam" rows="1" cols="60" placeholder="not supported"></textarea>
 				</div>
 			</p>
 		</div>

--- a/webinos/test/spec/ApplauncherSpec.js
+++ b/webinos/test/spec/ApplauncherSpec.js
@@ -1,0 +1,80 @@
+describe('Applauncher API', function() {
+	var applauncherService;
+
+	beforeEach(function() {
+		this.addMatchers({
+			toHaveProp: function(expected) {
+				return typeof this.actual[expected] !== "undefined";
+			}
+		});
+
+		webinos.discovery.findServices(new ServiceType("http://webinos.org/api/applauncher"), {
+			onFound: function (service) {
+				applauncherService = service;
+			}
+		});
+
+		waitsFor(function() {
+			return !!applauncherService;
+		}, "The discovery didn't find an Applauncher service", 5000);
+	});
+
+	it("should be available from the discovery", function() {
+		expect(applauncherService).toBeDefined();
+	});
+
+	it("has the necessary properties as service object", function() {
+		expect(applauncherService).toHaveProp("state");
+		expect(applauncherService).toHaveProp("api");
+		expect(applauncherService.api).toEqual(jasmine.any(String));
+		expect(applauncherService).toHaveProp("id");
+		expect(applauncherService.id).toEqual(jasmine.any(String));
+		expect(applauncherService).toHaveProp("displayName");
+		expect(applauncherService.displayName).toEqual(jasmine.any(String));
+		expect(applauncherService).toHaveProp("description");
+		expect(applauncherService.description).toEqual(jasmine.any(String));
+		expect(applauncherService).toHaveProp("icon");
+		expect(applauncherService.icon).toEqual(jasmine.any(String));
+		expect(applauncherService).toHaveProp("bindService");
+		expect(applauncherService.bindService).toEqual(jasmine.any(Function));
+	});
+
+	it("can be bound", function() {
+		var bound = false;
+
+		applauncherService.bindService({onBind: function(service) {
+			applauncherService = service;
+			bound = true;
+		}});
+
+		waitsFor(function() {
+			return bound;
+		}, "The service couldn't be bound", 500);
+
+		runs(function() {
+			expect(bound).toEqual(true);
+		});
+	});
+
+	it("has the necessary properties and functions as Applauncher API service", function() {
+		expect(applauncherService).toHaveProp("launchApplication");
+		expect(applauncherService.launchApplication).toEqual(jasmine.any(Function));
+		expect(applauncherService).toHaveProp("appInstalled");
+		expect(applauncherService.appInstalled).toEqual(jasmine.any(Function));
+	});
+
+	it('cat launch default web browser via launchApplication', function() {
+		var success;
+		applauncherService.launchApplication(function() {
+			success = true;
+		}, function(){}, "http://www.google.com");
+
+		waitsFor(function() {
+			return success;
+		});
+
+		runs(function() {
+			expect(success).toEqual(true);
+		});
+	});
+});

--- a/webinos/test/spec/DiscoverySpec.js
+++ b/webinos/test/spec/DiscoverySpec.js
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ *  Code contributed to the webinos project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2011 Alexander Futasz, Fraunhofer FOKUS
+ ******************************************************************************/
+
+describe("Discovery API", function() {
+
+	beforeEach(function() {
+	});
+
+	it("is available as webinos.discovery namespace", function() {
+		expect(webinos.discovery).toBeDefined();
+	});
+
+	it("has findServices function", function() {
+		expect(webinos.discovery.findServices).toEqual(jasmine.any(Function));
+	});
+
+	it("ServiceType constructor is available", function() {
+		expect(ServiceType).toEqual(jasmine.any(Function));
+	});
+
+	it("can find any services", function() {
+		var found;
+
+		webinos.discovery.findServices(new ServiceType("*"), {
+			onFound: function (service) {
+				found = true;
+			}
+		});
+
+		waitsFor(function() {
+			return found;
+		});
+
+		runs(function() {
+			expect(found).toEqual(true);
+		});
+	});
+
+	it("will timeout if no service is found", function() {
+		var found = false;
+
+		webinos.discovery.findServices(new ServiceType("non-existing service"), {
+			onFound: function (service) {
+				found = true;
+			}
+		}, {timeout: 0});
+
+		runs(function() {
+			expect(found).toEqual(false);
+		});
+	});
+});

--- a/webinos/test/spec/EventsSpec.js
+++ b/webinos/test/spec/EventsSpec.js
@@ -43,24 +43,18 @@ describe("Events API", function() {
 
 	it("has the necessary properties as service object", function() {
 		expect(eventsService).toHaveProp("state");
-		expect(eventsService).toHaveProp("api");
 		expect(eventsService.api).toEqual(jasmine.any(String));
-		expect(eventsService).toHaveProp("id");
 		expect(eventsService.id).toEqual(jasmine.any(String));
-		expect(eventsService).toHaveProp("displayName");
 		expect(eventsService.displayName).toEqual(jasmine.any(String));
-		expect(eventsService).toHaveProp("description");
 		expect(eventsService.description).toEqual(jasmine.any(String));
-		expect(eventsService).toHaveProp("icon");
 		expect(eventsService.icon).toEqual(jasmine.any(String));
-		expect(eventsService).toHaveProp("bindService");
 		expect(eventsService.bindService).toEqual(jasmine.any(Function));
 	});
 
 	it("can be bound", function() {
 		var bound = false;
 
-		eventsService.bind({onBind: function(service) {
+		eventsService.bindService({onBind: function(service) {
 			eventsService = service;
 			bound = true;
 		}});
@@ -75,11 +69,8 @@ describe("Events API", function() {
 	});
 
 	it("has the necessary properties and functions as Events API service", function() {
-		expect(eventsService).toHaveProp("createWebinosEvent");
 		expect(eventsService.createWebinosEvent).toEqual(jasmine.any(Function));
-		expect(eventsService).toHaveProp("addWebinosEventListener");
 		expect(eventsService.addWebinosEventListener).toEqual(jasmine.any(Function));
-		expect(eventsService).toHaveProp("removeWebinosEventListener");
 		expect(eventsService.removeWebinosEventListener).toEqual(jasmine.any(Function));
 	});
 
@@ -89,9 +80,7 @@ describe("Events API", function() {
 		expect(ev).toHaveProp("addressing");
 		expect(ev).toHaveProp("id");
 		expect(ev).toHaveProp("timeStamp");
-		expect(ev).toHaveProp("dispatchWebinosEvent");
 		expect(ev.dispatchWebinosEvent).toEqual(jasmine.any(Function));
-		expect(ev).toHaveProp("forwardWebinosEvent");
 		expect(ev.forwardWebinosEvent).toEqual(jasmine.any(Function));
 	});
 


### PR DESCRIPTION
Add tests for applauncher and discovery.
Improves the applauncher API implementation. It's not possible to start any executables of which the path is known, instead only URLs as applicationID are supported and get launched in the default web browser.
Improve tests for events by removing unnecessary property tests.

http://jira.webinos.org/browse/WP-135
