### PR TITLE
Added now module to package.json in order to use Vehicle simulator out of the box

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "ansi": "0.0.x",
     "connect": "2.x.x",
     "mdns": "0.x.x",
-    "jsormdb": "0.1.x"
+    "jsormdb": "0.1.x",
+    "now": "0.8.1"
   },
   "engines" : {
     "node" : ">=0.6.18",


### PR DESCRIPTION
The Vehicle simulator requires the now module in order to sync the simulator data with the PZP implementation. In the installation process the now module is not installed by default and has to be installed by default.

Jira issue: http://jira.webinos.org/browse/WP-137
