### PR TITLE
Fixed building Webinos on the Mac

### DIFF
--- a/webinos/common/manager/keystore/src/binding.gyp
+++ b/webinos/common/manager/keystore/src/binding.gyp
@@ -1,6 +1,6 @@
 {
   'variables': {
-    'module_name': 'keystore',#Specify the module name here
+    'module_name': 'keystore'#Specify the module name here
 	#you may override the variables found in node_module.gypi here or through command line
   },
   'targets': [
@@ -9,33 +9,36 @@
 	    'target_name': '<(module_name)',
 	    'product_name':'<(module_name)',
 		'sources': [ #Specify your source files here
-			"ksImpl.cpp",
-			"ksImpl.h",
 			"KeyStoreException.h",
+			"ksImpl.cpp",
+			"ksImpl.h"
 		],
 		'conditions': [
-        [ 'OS=="darwin"', {
+        [ 'OS=="mac"', {
 		  'sources': [            
-			'ksImpl_Darwin.cpp',
+			'ksImpl_Darwin.cpp'
 		  ],
-          'libraries': ['-g','-framework','CoreFoundation','-framework','Security','-lssl','-lcrypto' ],
-        }],
+          'libraries': ['-g','-framework CoreFoundation','-framework Security','-lssl','-lcrypto', '-D_GNU_SOURCE'],
+		  'cflags!': [ '-fno-exceptions' ],
+		  'cflags_cc!': [ '-fno-exceptions' ],  
+	      'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES' }
+		}],
         [ 'OS=="win"', {
 		  'sources': [            
-			'ksImpl_NotImplemented.cpp',
-		  ],
+			'ksImpl_NotImplemented.cpp'
+		  ]
         }],
 		[ 'OS=="linux"', {
 		  'sources': [            
-			'ksImpl_Linux.cpp',
+			'ksImpl_Linux.cpp'
 		  ],
 		  'cflags': ['<!@(pkg-config --cflags gnome-keyring-1)'], #call pkg-config to get the cflags
 		  'libraries': ['<!@(pkg-config --libs-only-l gnome-keyring-1)'], #call pkg-config to get the libraries
 		  'cflags!': [ '-fno-exceptions' ], #this is required to allow the class to throw exceptions
-		  'cflags_cc!': [ '-fno-exceptions' ],
-        }],
+		  'cflags_cc!': [ '-fno-exceptions' ]
+        }]
       ],
-    },
+    }
   ] # end targets
 }
 


### PR DESCRIPTION
Changed platform from 'darwin' to 'mac'. Changed 'libraries' so that framework parameters are in a single string value and enabled exceptions on the compiler.

Jira issue: WP-88
