### PR TITLE
Wp 146 tests for payment and payment reintegration

### DIFF
--- a/webinos/api/payment/lib/rpc_payment.js
+++ b/webinos/api/payment/lib/rpc_payment.js
@@ -27,8 +27,9 @@ var basket = null;
  * Webinos Service constructor.
  * @param rpcHandler A handler for functions that use RPC to deliver their result.  
  */
-var PaymentModule = function(rpcHandler) {
+var PaymentModule = function(rpcHandler, params) {
         // inherit from RPCWebinosService
+ console.log("{PAYMENT CONSTRUCTION");        
         this.base = RPCWebinosService;
         this.base({
                 api:'http://webinos.org/api/payment',

--- a/webinos/api/payment/package.json
+++ b/webinos/api/payment/package.json
@@ -1,4 +1,4 @@
-{ "name": "sensors"
+{ "name": "payment"
 , "publishConfig": { "tag": "alpha" }
 , "description": "Payment API"
 , "keywords": [ "webinos", "payment", "API"]

--- a/webinos/test/JasmineSpecRunner.html
+++ b/webinos/test/JasmineSpecRunner.html
@@ -19,7 +19,8 @@
   <script type="text/javascript" src="spec/discovery/DiscoverySpec.js"></script>
   <script type="text/javascript" src="spec/geolocation/GeolocationSpec.js"></script>
   <script type="text/javascript" src="spec/gallery/gallerySpec.js"></script>
-  <script type="text/javascript" src="spec/applauncher/applauncherSpec.js"></script>
+  <script type="text/javascript" src="spec/applauncher/applauncherSpec.js"></script>  
+  <script type="text/javascript" src="spec/payment/PaymentSpec.js"></script>
   <script type="text/javascript" src="spec/vehicle/vehicleSpec.js"></script>
   <script type="text/javascript" src="spec/tv/TVControlSpec.js"></script>
 

--- a/webinos/test/build.xml
+++ b/webinos/test/build.xml
@@ -33,6 +33,7 @@
             	<file name="wrt/lib/webinos.contacts.js"/>
             	<file name="wrt/lib/webinos.devicestatus.js"/>
 		<file name="wrt/lib/webinos.discovery.js"/>
+		<file name="wrt/lib/webinos.payment.js"/>
             </sources>
         </jscompiler>
     </target>	

--- a/webinos/test/spec/payment/PaymentSpec.js
+++ b/webinos/test/spec/payment/PaymentSpec.js
@@ -1,0 +1,938 @@
+/*******************************************************************************
+ *  Code contributed to the webinos project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2012 Christian Fuhrhop, Fraunhofer FOKUS
+ ******************************************************************************/
+
+describe("Payment API", function() {
+        var paymentService;
+
+        beforeEach(function() {
+                this.addMatchers({
+                        toHaveProp: function(expected) {
+                                return typeof this.actual[expected] !== "undefined";
+                        }
+                });
+
+                webinos.discovery.findServices(new ServiceType("http://webinos.org/api/payment"), {
+                        onFound: function (service) {
+                                paymentService = service;                                
+                        }
+                });
+
+                waitsFor(function() {
+                        return !!paymentService;
+                }, "The discovery didn't find a Payment service", 5000);
+        });
+
+        it("should be available from the discovery", function() {
+                expect(paymentService).toBeDefined();
+        });
+
+        it("has the necessary properties as service object", function() {
+                expect(paymentService).toHaveProp("state");
+                expect(paymentService.api).toEqual(jasmine.any(String));
+                expect(paymentService.id).toEqual(jasmine.any(String));
+                expect(paymentService.displayName).toEqual(jasmine.any(String));
+                expect(paymentService.description).toEqual(jasmine.any(String));
+                expect(paymentService.icon).toEqual(jasmine.any(String));
+                expect(paymentService.bindService).toEqual(jasmine.any(Function));
+        });
+
+        it("can be bound", function() {
+                var bound = false;
+
+                paymentService.bindService({onBind: function(service) {
+                        paymentService = service;
+                        bound = true;
+                }});
+
+                waitsFor(function() {
+                    return bound;
+                }, "The service couldn't be bound", 500);
+
+                runs(function() {
+                        expect(bound).toEqual(true);
+                });
+        });
+
+        it("has the necessary functions as Payment API service", function() {
+                expect(paymentService.createShoppingBasket).toEqual(jasmine.any(Function));
+        });
+        
+        var myBasket = null;
+        var myItem= null;
+        var oldTotal = null;
+        
+        it("can not create a shopping basket with null payment provider",  function() {
+                var gotBasket = true;
+                var gotCallback = false;
+                
+                 paymentService.createShoppingBasket(
+                           function (basket) {myBasket = basket;gotBasket=true;gotCallback=true;},
+                            function (error) {gotBasket=false; gotCallback=true;},
+                            null,"mycustomer","myshop"
+                  );    
+                                            
+                waitsFor(function() {
+                        return gotCallback;
+                }, "createShoppingBasket callback to be called.", 10000);
+
+                runs(function() {
+                        expect(gotBasket).toEqual(false);                        
+                });
+
+        });
+        
+        it("can not create a shopping basket with null customer",  function() {
+                var gotBasket = true;
+                var gotCallback = false;
+                
+                 paymentService.createShoppingBasket(
+                           function (basket) {myBasket = basket;gotBasket=true; gotCallback=true;},
+                            function (error) {gotBasket=false; gotCallback=true; },
+                            "Local test",null,"myshop"
+                  );    
+                                            
+                waitsFor(function() {
+                         return gotCallback;
+                }, "createShoppingBasket callback to be called.", 10000);
+
+                runs(function() {
+                        expect(gotBasket).toEqual(false);                        
+                });
+
+        });
+        
+        it("can not create a shopping basket with null shop",  function() {
+                var gotBasket = true;
+                var gotCallback = false;
+                
+                 paymentService.createShoppingBasket(
+                           function (basket) {myBasket = basket;gotBasket=true; gotCallback=true;},
+                            function (error) {gotBasket=false; gotCallback=true; },
+                             "Local test","mycustomer",null
+                  );    
+                                            
+                waitsFor(function() {
+                        return gotCallback;
+                }, "createShoppingBasket callback to be called.", 10000);
+
+                runs(function() {
+                        expect(gotBasket).toEqual(false);                        
+                });
+
+        });
+        
+        it("can create a shopping basket",  function() {
+                var gotBasket = false;
+                var gotCallback = false;
+                
+                 paymentService.createShoppingBasket(
+                           function (basket) {myBasket = basket;gotBasket=true; gotCallback=true;},
+                            function (error) {gotBasket=false;  gotCallback=true;},
+                            "Local test","mycustomer","myshop"
+                  );    
+                                            
+                waitsFor(function() {
+                         return gotCallback;
+                }, "createShoppingBasket callback to be called.", 10000);
+
+                runs(function() {
+                        expect(gotBasket).toEqual(true);                        
+                });
+
+        });
+        
+        it("has the necessary properties and functions for a shopping basket", function() {
+                expect(myBasket.addItem).toEqual(jasmine.any(Function));
+                expect(myBasket.update).toEqual(jasmine.any(Function));
+                expect(myBasket.checkout).toEqual(jasmine.any(Function));
+                expect(myBasket.release).toEqual(jasmine.any(Function));
+                expect(myBasket).toHaveProp("items");
+                expect(myBasket).toHaveProp("extras");
+                expect(myBasket).toHaveProp("totalBill");
+       });
+       
+
+        it("has the necessary properties and functions for a shopping item", function() {     
+                      myItem=new ShoppingItem();
+                      expect(myItem).toHaveProp("productID");
+                      expect(myItem).toHaveProp("description");
+                      expect(myItem).toHaveProp("currency");
+                      expect(myItem).toHaveProp("itemPrice");
+                      expect(myItem).toHaveProp("itemCount");
+                      expect(myItem).toHaveProp("itemsPrice");
+       });
+         
+        it("can add an item to a shopping basket",  function() {
+                var addedItem = false;
+                var gotCallback = false;
+                
+                 myItem.productID="1";
+                 myItem.description="One Item";
+                 myItem.currency="EUR";
+                 myItem.itemPrice=12.34;
+                 myItem.itemCount=1;
+                 myItem.itemsPrice=12.34;
+
+                 myBasket.addItem(
+                           function () {addedItem=true; gotCallback=true;},
+                           function (error) {addedItem=false; gotCallback=true;},
+                            myItem
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                        return addedItem;
+                }, "addedItem callback to be called.", 10000);
+
+                runs(function() {
+                        expect(addedItem).toEqual(true);                        
+                });
+
+        });
+
+        it("has one item in the shopping basket",  function() {
+         expect(myBasket.items.length).toEqual(1);              
+        });
+         
+        it("can add a second item to a shopping basket",  function() {
+                var addedItem = false;
+                var gotCallback = false;
+                
+                 myItem.productID="2";
+                 myItem.description="Another Item";
+                 myItem.currency="EUR";
+                 myItem.itemPrice=43.21;
+                 myItem.itemCount=1;
+                 myItem.itemsPrice=43.21;
+
+                 myBasket.addItem(
+                           function () {addedItem=true; gotCallback=true;},
+                           function (error) {addedItem=false; gotCallback=true;},
+                            myItem
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                         return gotCallback;
+                }, "addedItem callback to be called.", 10000);
+
+                runs(function() {
+                        expect(addedItem).toEqual(true);                        
+                });
+
+        });
+
+        it("has two items in the shopping basket",  function() {
+         expect(myBasket.items.length).toEqual(2);              
+        });
+
+        it("total cost is at least cost of the two items",  function() {
+         // might be more if VAT or other costs are added automatically...
+         expect(myBasket.totalBill>=(12.34+43.21)).toEqual(true);              
+         
+         // store old total to make sure it doesn't change on faulty item adds
+         oldTotal=myBasket.totalBill;
+        });
+
+
+        it("can not add item without currency value ",  function() {
+                var addedItem = true;
+                var gotCallback = false;
+                
+                 myItem.productID="3";
+                 myItem.description="Dummy Item";
+                 myItem.currency=null;
+                 myItem.itemPrice=11.11;
+                 myItem.itemCount=1;
+                 myItem.itemsPrice=11.11;
+
+                 myBasket.addItem(
+                           function () {addedItem=true; gotCallback=true;},
+                           function (error) {addedItem=false; gotCallback=true;},
+                            myItem
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                        return gotCallback;
+                }, "addedItem callback to be called.", 10000);
+
+                runs(function() {
+                        expect(addedItem).toEqual(false);                        
+                });
+
+        });
+
+        it("can not add item with null item count ",  function() {
+                var addedItem = true;
+                var gotCallback = false;
+                
+                 myItem.productID="3";
+                 myItem.description="Dummy Item";
+                 myItem.currency="EUR";
+                 myItem.itemPrice=11.11;
+                 myItem.itemCount=null;
+                 myItem.itemsPrice=11.11;
+
+                 myBasket.addItem(
+                           function () {addedItem=true; gotCallback=true;},
+                           function (error) {addedItem=false; gotCallback=true;},
+                            myItem
+                            );    
+
+                            
+                                           
+                waitsFor(function() {
+                        return gotCallback;
+                }, "addedItem callback to be called.", 10000);
+
+                runs(function() {
+                        expect(addedItem).toEqual(false);                        
+                });
+
+        });
+        
+        it("can not add item with zero item count ",  function() {
+                var addedItem = true;
+                var gotCallback = false;
+                
+                 myItem.productID="3";
+                 myItem.description="Dummy Item";
+                 myItem.currency="EUR";
+                 myItem.itemPrice=11.11;
+                 myItem.itemCount=0;
+                 myItem.itemsPrice=11.11;
+
+                 myBasket.addItem(
+                           function () {addedItem=true; gotCallback=true;},
+                           function (error) {addedItem=false; gotCallback=true;},
+                            myItem
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                         return gotCallback;
+                }, "addedItem callback to be called.", 10000);
+
+                runs(function() {
+                        expect(addedItem).toEqual(false);                        
+                });
+
+        });
+        it("does not change shopping basket when item additions fail",  function() {
+         expect(myBasket.items.length).toEqual(2);              
+         expect(myBasket.totalBill==oldTotal).toEqual(true);              
+        });
+        
+        it("can update basket",  function() {
+                var updatedBasket = false;
+                var gotCallback = false;
+
+                 myBasket.update(
+                           function () {updatedBasket=true; gotCallback=true;},
+                           function (error) {updatedBasket=false; gotCallback=true;}
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                       return gotCallback;
+                }, "update callback to be called.", 10000);
+
+                runs(function() {
+                        expect(updatedBasket).toEqual(true);                        
+                });
+
+        });
+        it("can checkout basket",  function() {
+                var checkoutBasket = false;
+                var gotCallback = false;
+
+                 myBasket.checkout(
+                           function () {checkoutBasket=true; gotCallback=true;},
+                           function (error) {checkoutBasket=false; gotCallback=true;}
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                       return gotCallback;
+                }, "checkout callback to be called.", 10000);
+
+                runs(function() {
+                        expect(checkoutBasket).toEqual(true);                        
+                });
+
+        });
+        
+        it("can not add an item after checkout",  function() {
+                var addedItem = true;
+                var gotCallback = false;
+                
+                 myItem.productID="1";
+                 myItem.description="One Item";
+                 myItem.currency="EUR";
+                 myItem.itemPrice=12.34;
+                 myItem.itemCount=1;
+                 myItem.itemsPrice=12.34;
+
+                 myBasket.addItem(
+                           function () {addedItem=true; gotCallback=true;},
+                           function (error) {addedItem=false; gotCallback=true;},
+                            myItem
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                        return gotCallback;
+                }, "addedItem callback to be called.", 10000);
+
+                runs(function() {
+                        expect(addedItem).toEqual(false);                        
+                });
+
+        });
+
+        it("can not update basket after checkout",  function() {
+                var updatedBasket = true;
+                var gotCallback = false;
+
+                 myBasket.update(
+                           function () {updatedBasket=true; gotCallback=true;},
+                           function (error) {updatedBasket=false; gotCallback=true;}
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                        return gotCallback;
+                }, "update callback to be called.", 10000);
+
+                runs(function() {
+                        expect(updatedBasket).toEqual(false);                        
+                });
+
+        });
+        it("can not checkout basket again after checkout",  function() {
+                var checkoutBasket = true;
+                var gotCallback = false;
+
+                 myBasket.checkout(
+                           function () {checkoutBasket=true; gotCallback=true;},
+                           function (error) {checkoutBasket=false; gotCallback=true;}
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                        return gotCallback;
+                }, "checkout callback to be called.", 10000);
+
+                runs(function() {
+                        expect(checkoutBasket).toEqual(false);                        
+                });
+
+        });
+
+        it("can release basket",  function() {
+                var releasedBasket = false;
+
+                 myBasket.release(  );    
+                 releasedBasket=true;
+
+                runs(function() {
+                        expect(releasedBasket).toEqual(true);                        
+                });
+
+        });
+        
+        it("can not add an item to a shopping basket after basket release",  function() {
+                var addedItem = true;
+                var gotCallback = false;
+                
+                 myItem.productID="1";
+                 myItem.description="One Item";
+                 myItem.currency="EUR";
+                 myItem.itemPrice=12.34;
+                 myItem.itemCount=1;
+                 myItem.itemsPrice=12.34;
+
+                 myBasket.addItem(
+                           function () {addedItem=true; gotCallback=true;},
+                           function (error) {addedItem=false; gotCallback=true;},
+                            myItem
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                       return gotCallback;
+                }, "addedItem callback to be called.", 10000);
+
+                runs(function() {
+                        expect(addedItem).toEqual(false);                        
+                });
+
+        });
+
+        it("can not update a shopping basket after basket release",  function() {
+                var updatedBasket = true;
+                var gotCallback = false;
+
+                 myBasket.update(
+                           function () {updatedBasket=true; gotCallback=true;},
+                           function (error) {updatedBasket=false; gotCallback=true;}
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                         return gotCallback;
+                }, "update callback to be called.", 10000);
+
+                runs(function() {
+                        expect(updatedBasket).toEqual(false);                        
+                });
+
+        });
+
+        it("can not checkout a shopping basket after basket release",  function() {
+                var checkoutBasket = true;
+                var gotCallback = false;
+
+                 myBasket.update(
+                           function () {checkoutBasket=true; gotCallback=true;},
+                           function (error) {checkoutBasket=false; gotCallback=true;}
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                        return gotCallback;
+                }, "checkout callback to be called.", 10000);
+
+                runs(function() {
+                        expect(checkoutBasket).toEqual(false);                        
+                });
+
+        });
+
+
+        it("can not create a GSMA shopping basket with unknown customer",  function() {
+                var gotBasket = true;
+                var gotCallback = false;
+                
+                 paymentService.createShoppingBasket(
+                           function (basket) {myBasket = basket;gotBasket=true; gotCallback=true;},
+                            function (error) {gotBasket=false; gotCallback=true; },
+                            "GSMA", "NOSUCHCUSTOMER" ,"webinosTest"
+                  );    
+                                            
+                waitsFor(function() {
+                         return gotCallback;
+                }, "createShoppingBasket callback to be called.", 10000);
+
+                runs(function() {
+                        expect(gotBasket).toEqual(false);                        
+                });
+
+        });
+        
+        it("can not create a GSMA shopping basket with unknown shop",  function() {
+                var gotBasket = true;
+                var gotCallback = false;
+                
+                 paymentService.createShoppingBasket(
+                           function (basket) {myBasket = basket;gotBasket=true; gotCallback=true;},
+                            function (error) {gotBasket=false; gotCallback=true; },
+                            "GSMA", "+16309700001" ,"NOSUCHSHOP"
+                  );    
+                                            
+                waitsFor(function() {
+                        return gotCallback;
+                }, "createShoppingBasket callback to be called.", 10000);
+
+                runs(function() {
+                        expect(gotBasket).toEqual(false);                        
+                });
+
+        });
+        
+        it("can create a GSMA shopping basket",  function() {
+                var gotBasket = false;
+                var gotCallback = false;
+                
+                 paymentService.createShoppingBasket(
+                           function (basket) {myBasket = basket;gotBasket=true; gotCallback=true;},
+                            function (error) {gotBasket=false;  gotCallback=true;},
+                             "GSMA", "+16309700001" ,"webinosTest"
+                  );    
+                                            
+                waitsFor(function() {
+                         return gotCallback;
+                }, "createShoppingBasket callback to be called.", 10000);
+
+                runs(function() {
+                        expect(gotBasket).toEqual(true);                        
+                });
+
+        });
+
+        it("can add an item to a GSMA shopping basket",  function() {
+                var addedItem = false;
+                var gotCallback = false;
+                
+                 myItem.productID="1";
+                 myItem.description="One Item";
+                 myItem.currency="EUR";
+                 myItem.itemPrice=12.34;
+                 myItem.itemCount=1;
+                 myItem.itemsPrice=12.34;
+
+                 myBasket.addItem(
+                           function () {addedItem=true; gotCallback=true;},
+                           function (error) {addedItem=false; gotCallback=true;},
+                            myItem
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                        return gotCallback;
+                }, "addedItem callback to be called.", 10000);
+
+                runs(function() {
+                        expect(addedItem).toEqual(true);                        
+                });
+
+        });
+
+        it("has one item in the GSMA shopping basket",  function() {
+         expect(myBasket.items.length).toEqual(1);              
+        });
+         
+        it("can add a second item to a GSMA shopping basket",  function() {
+                var addedItem = false;
+                var gotCallback = false;
+                
+                 myItem.productID="2";
+                 myItem.description="Another Item";
+                 myItem.currency="EUR";
+                 myItem.itemPrice=43.21;
+                 myItem.itemCount=1;
+                 myItem.itemsPrice=43.21;
+
+                 myBasket.addItem(
+                           function () {addedItem=true; gotCallback=true;},
+                           function (error) {addedItem=false; gotCallback=true;},
+                            myItem
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                         return gotCallback;
+                }, "addedItem callback to be called.", 10000);
+
+                runs(function() {
+                        expect(addedItem).toEqual(true);                        
+                });
+
+        });
+
+        it("has two items in the GSMA shopping basket",  function() {
+         expect(myBasket.items.length).toEqual(2);              
+        });
+
+        it("total cost is at least cost of the two items",  function() {
+         // might be more if VAT or other costs are added automatically...
+         expect(myBasket.totalBill>=(12.34+43.21)).toEqual(true);              
+         
+         // store old total to make sure it doesn't change on faulty item adds
+         oldTotal=myBasket.totalBill;
+        });
+
+
+        it("can not add item without currency value to the GSMA shopping basket",  function() {
+                var addedItem = true;
+                var gotCallback = false;
+                
+                 myItem.productID="3";
+                 myItem.description="Dummy Item";
+                 myItem.currency=null;
+                 myItem.itemPrice=11.11;
+                 myItem.itemCount=1;
+                 myItem.itemsPrice=11.11;
+
+                 myBasket.addItem(
+                           function () {addedItem=true; gotCallback=true;},
+                           function (error) {addedItem=false; gotCallback=true;},
+                            myItem
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                        return gotCallback;
+                }, "addedItem callback to be called.", 10000);
+
+                runs(function() {
+                        expect(addedItem).toEqual(false);                        
+                });
+
+        });
+
+        it("can not add item with null item count to the GSMA shopping basket ",  function() {
+                var addedItem = true;
+                var gotCallback = false;
+                
+                 myItem.productID="3";
+                 myItem.description="Dummy Item";
+                 myItem.currency="EUR";
+                 myItem.itemPrice=11.11;
+                 myItem.itemCount=null;
+                 myItem.itemsPrice=11.11;
+
+                 myBasket.addItem(
+                           function () {addedItem=true; gotCallback=true;},
+                           function (error) {addedItem=false; gotCallback=true;},
+                            myItem
+                            );    
+
+                            
+                                           
+                waitsFor(function() {
+                        return gotCallback;
+                }, "addedItem callback to be called.", 10000);
+
+                runs(function() {
+                        expect(addedItem).toEqual(false);                        
+                });
+
+        });
+        
+        it("can not add item with zero item count to the GSMA shopping basket",  function() {
+                var addedItem = true;
+                var gotCallback = false;
+                
+                 myItem.productID="3";
+                 myItem.description="Dummy Item";
+                 myItem.currency="EUR";
+                 myItem.itemPrice=11.11;
+                 myItem.itemCount=0;
+                 myItem.itemsPrice=11.11;
+
+                 myBasket.addItem(
+                           function () {addedItem=true; gotCallback=true;},
+                           function (error) {addedItem=false; gotCallback=true;},
+                            myItem
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                         return gotCallback;
+                }, "addedItem callback to be called.", 10000);
+
+                runs(function() {
+                        expect(addedItem).toEqual(false);                        
+                });
+
+        });
+        it("does not change GSMA shopping basket when item additions fail",  function() {
+         expect(myBasket.items.length).toEqual(2);              
+         expect(myBasket.totalBill==oldTotal).toEqual(true);              
+        });
+        
+        it("can update GSMA shopping basket",  function() {
+                var updatedBasket = false;
+                var gotCallback = false;
+
+                 myBasket.update(
+                           function () {updatedBasket=true; gotCallback=true;},
+                           function (error) {updatedBasket=false; gotCallback=true;}
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                       return gotCallback;
+                }, "update callback to be called.", 10000);
+
+                runs(function() {
+                        expect(updatedBasket).toEqual(true);                        
+                });
+
+        });
+        it("can checkout GSMA shopping basket",  function() {
+                var checkoutBasket = false;
+                var gotCallback = false;
+
+                 myBasket.checkout(
+                           function () {checkoutBasket=true; gotCallback=true;},
+                           function (error) {checkoutBasket=false; gotCallback=true;}
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                       return gotCallback;
+                }, "checkout callback to be called.", 10000);
+
+                runs(function() {
+                        expect(checkoutBasket).toEqual(true);                        
+                });
+
+        });
+        
+        it("can not add an item after checkout to the GSMA shopping basket",  function() {
+                var addedItem = true;
+                var gotCallback = false;
+                
+                 myItem.productID="1";
+                 myItem.description="One Item";
+                 myItem.currency="EUR";
+                 myItem.itemPrice=12.34;
+                 myItem.itemCount=1;
+                 myItem.itemsPrice=12.34;
+
+                 myBasket.addItem(
+                           function () {addedItem=true; gotCallback=true;},
+                           function (error) {addedItem=false; gotCallback=true;},
+                            myItem
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                        return gotCallback;
+                }, "addedItem callback to be called.", 10000);
+
+                runs(function() {
+                        expect(addedItem).toEqual(false);                        
+                });
+
+        });
+
+        it("can not update GSMA shopping basket after checkout ",  function() {
+                var updatedBasket = true;
+                var gotCallback = false;
+
+                 myBasket.update(
+                           function () {updatedBasket=true; gotCallback=true;},
+                           function (error) {updatedBasket=false; gotCallback=true;}
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                        return gotCallback;
+                }, "update callback to be called.", 10000);
+
+                runs(function() {
+                        expect(updatedBasket).toEqual(false);                        
+                });
+
+        });
+        it("can not checkout GSMA shopping basket again after checkout",  function() {
+                var checkoutBasket = true;
+                var gotCallback = false;
+
+                 myBasket.checkout(
+                           function () {checkoutBasket=true; gotCallback=true;},
+                           function (error) {checkoutBasket=false; gotCallback=true;}
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                        return gotCallback;
+                }, "checkout callback to be called.", 10000);
+
+                runs(function() {
+                        expect(checkoutBasket).toEqual(false);                        
+                });
+
+        });
+
+        it("can release GSMA shopping basket",  function() {
+                var releasedBasket = false;
+
+                 myBasket.release(  );    
+                 releasedBasket=true;
+
+                runs(function() {
+                        expect(releasedBasket).toEqual(true);                        
+                });
+
+        });
+        
+        it("can not add an item to a GSMA shopping basket after basket release",  function() {
+                var addedItem = true;
+                var gotCallback = false;
+                
+                 myItem.productID="1";
+                 myItem.description="One Item";
+                 myItem.currency="EUR";
+                 myItem.itemPrice=12.34;
+                 myItem.itemCount=1;
+                 myItem.itemsPrice=12.34;
+
+                 myBasket.addItem(
+                           function () {addedItem=true; gotCallback=true;},
+                           function (error) {addedItem=false; gotCallback=true;},
+                            myItem
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                       return gotCallback;
+                }, "addedItem callback to be called.", 10000);
+
+                runs(function() {
+                        expect(addedItem).toEqual(false);                        
+                });
+
+        });
+
+        it("can not update a GSMA shopping basket after basket release",  function() {
+                var updatedBasket = true;
+                var gotCallback = false;
+
+                 myBasket.update(
+                           function () {updatedBasket=true; gotCallback=true;},
+                           function (error) {updatedBasket=false; gotCallback=true;}
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                         return gotCallback;
+                }, "update callback to be called.", 10000);
+
+                runs(function() {
+                        expect(updatedBasket).toEqual(false);                        
+                });
+
+        });
+
+        it("can not checkout a GSMA shopping basket after basket release",  function() {
+                var checkoutBasket = true;
+                var gotCallback = false;
+
+                 myBasket.update(
+                           function () {checkoutBasket=true; gotCallback=true;},
+                           function (error) {checkoutBasket=false; gotCallback=true;}
+                            );    
+                            
+                                            
+                waitsFor(function() {
+                        return gotCallback;
+                }, "checkout callback to be called.", 10000);
+
+                runs(function() {
+                        expect(checkoutBasket).toEqual(false);                        
+                });
+
+        });
+        
+
+});

--- a/webinos/test/spec/payment/SpecRunner.html
+++ b/webinos/test/spec/payment/SpecRunner.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+  "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+  <title>Jasmine Spec Runner</title>
+
+  <link rel="stylesheet" type="text/css" href="../../lib/jasmine-1.2.0/jasmine.css">
+  <script type="text/javascript" src="../../lib/jasmine-1.2.0/jasmine.js"></script>
+  <script type="text/javascript" src="../../lib/jasmine-1.2.0/jasmine-html.js"></script>
+  <script type="text/javascript" src="../../lib/jasmine-execute.js"></script>
+
+  <!-- include source files here... -->
+  <script type="text/javascript" src="../../client/webinos.js"></script>
+
+  <!-- include spec files here... -->
+  <script type="text/javascript" src="PaymentSpec.js"></script>
+
+</head>
+
+<body>
+</body>
+</html>

--- a/webinos/wrt/lib/webinos.payment.js
+++ b/webinos/wrt/lib/webinos.payment.js
@@ -1,0 +1,301 @@
+/*******************************************************************************
+*  Code contributed to the webinos project
+* 
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*  
+*     http://www.apache.org/licenses/LICENSE-2.0
+*  
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* 
+* Copyright 2012 Christian Fuhrhop, Fraunhofer FOKUS
+******************************************************************************/
+
+(function() {
+ //Payment Module Functionality
+
+        PaymentModule = function (obj){      
+                this.base = WebinosService;
+                this.base(obj);
+        };
+
+    var rpcServiceProviderID, rpcCustomerID, rpcShopID;
+
+        PaymentModule.prototype = new WebinosService;
+        
+        /**
+         * To bind the service.
+         * @param bindCB BindCallback object.
+         */
+        PaymentModule.prototype.bindService = function (bindCB, serviceId) {
+                this.listenAttr = {};
+                
+                if (typeof bindCB.onBind === 'function') {
+                        bindCB.onBind(this);
+                };
+        }
+
+
+    PaymentModule.prototype.createShoppingBasket = function (successCallback, errorCallback, serviceProviderID, customerID, shopID) {
+                rpcServiceProviderID=serviceProviderID;
+                rpcCustomerID=customerID;
+                rpcShopID=shopID;
+                
+                var arguments = new Array();
+                arguments[0]=rpcServiceProviderID;
+                arguments[1]=rpcCustomerID;
+                arguments[2]=rpcShopID;
+                var self = this;
+                var rpc = webinos.rpcHandler.createRPC(this, "createShoppingBasket", arguments);
+                webinos.rpcHandler.executeRPC(rpc,
+                                function (params){
+                                        successCallback(new ShoppingBasket(self));
+                                },
+                                function (error){errorCallback(error);}
+                );
+        }
+    /**
+     * The ShoppingItem captures the attributes of a single shopping product
+     *
+     * 
+     * The shopping basket represents a current payment action and allows to 
+     * add a number of items to the basket before proceeding to checkout.
+     * 
+     */
+    ShoppingItem = function (obj) {
+
+        // initialize attributes
+
+        this.productID = "";
+        this.description = "";
+        this.currency = "EUR";
+        this.itemPrice = 0.0;
+        this.itemCount = 0;
+        this.itemsPrice = 0.0;
+        this.base = WebinosService;
+        this.base(obj);
+    };        
+    /**
+     * An id that allows the shop to identify the purchased item
+     *
+     * 
+     * No exceptions
+     * 
+     */
+    ShoppingItem.prototype.productID = ""
+
+    /**
+     * A human-readable text to appear on the bill, so the user can easily see what they bought.
+     *
+     * 
+     * No exceptions
+     * 
+     */
+    ShoppingItem.prototype.description = "";
+
+    /**
+     * The 3-figure code as per ISO 4217.
+     *
+     * 
+     * No exceptions
+     * 
+     */
+    ShoppingItem.prototype.currency = "EUR";
+
+    /**
+     * The price per individual item in the currency given above, a negative number represents a refund.
+     *
+     * 
+     * No exceptions
+     * 
+     */
+    ShoppingItem.prototype.itemPrice = 0.0;
+
+    /**
+     * The number of identical items purchased
+     *
+     * 
+     * No exceptions
+     * 
+     */
+    ShoppingItem.prototype.itemCount = 0;
+
+    /**
+     * Price for all products in this shopping item.
+     *
+     * 
+     * Typically this is itemPrice*itemCount, but special '3 for 2' rebates might apply.
+     * 
+     * Updated by the shopping basket update function.
+     * 
+     * No exceptions
+     * 
+     */
+    ShoppingItem.prototype.itemsPrice = 0.0;
+
+        /**
+     * The ShoppingBasket interface provides access to a shopping basket
+     *
+     * 
+     * The shopping basket represents a current payment action and allows to 
+     * add a number of items to the basket before proceeding to checkout.
+     * 
+     */
+    ShoppingBasket = function (obj) {
+
+        // initialize attributes
+        this.items =new Array(); 
+        this.extras =new Array(); 
+        this.totalBill = 0.0;        
+        this.base = WebinosService;
+        this.base(obj);
+    };
+  
+    
+    /**
+     * List of items currently in the shopping basket.
+     *
+     * 
+     * These are the items that have been added with addItem.
+     * 
+     * No exceptions
+     * 
+     */
+    ShoppingBasket.prototype.items =  null;
+
+    /**
+     * Automatically generated extra items, typically rebates, taxes and shipping costs.
+     *
+     * 
+     * These items are automatically added to the shopping basket by update()
+     * (or after the addition of an item to the basket).
+     * 
+     * These items can contain such 'virtual' items as payback schemes, rebates, taxes,
+     * shipping costs and other items that are calculated on the basis of the regular
+     * items added.
+     * 
+     * No exceptions
+     * 
+     */
+    ShoppingBasket.prototype.extras = null;
+
+    /**
+     * The total amount that will be charged to the user on checkout.
+     *
+     * 
+     * Will be updated by update(), may be updated by addItem().
+     * 
+     * No exceptions
+     * 
+     */
+    ShoppingBasket.prototype.totalBill = 0.0;
+
+    /**
+     * Adds an item to a shopping basket.
+     *
+     */
+    ShoppingBasket.prototype.addItem = function (successCallback, errorCallback, item) {
+                var arguments = new Array();
+                arguments[0]=rpcServiceProviderID;
+                arguments[1]=rpcCustomerID;
+                arguments[2]=rpcShopID;
+                arguments[3]=this;
+                arguments[4]=item;
+                var self = this;
+                var rpc = webinos.rpcHandler.createRPC(this, "addItem", arguments);
+                webinos.rpcHandler.executeRPC(rpc,
+                                function (params){
+                                        
+                                              self.items=params.items;
+                                              self.extras=params.extras;
+                                              self.totalBill=params.totalBill;
+                                        successCallback();
+                                },
+                                function (error){errorCallback(error);}
+                );
+    };
+
+  /**
+     * Updates the shopping basket
+     *
+     * 
+     */
+    ShoppingBasket.prototype.update = function (successCallback, errorCallback) {
+                var arguments = new Array();
+                arguments[0]=rpcServiceProviderID;
+                arguments[1]=rpcCustomerID;
+                arguments[2]=rpcShopID;
+                arguments[3]=this;
+                var self = this;
+                var rpc = webinos.rpcHandler.createRPC(this, "update", arguments);
+                webinos.rpcHandler.executeRPC(rpc,
+                                function (params){                                       
+                                              self.items=params.items;
+                                              self.extras=params.extras;
+                                              self.totalBill=params.totalBill;
+                                        successCallback();
+                                },
+                                function (error){errorCallback(error);}
+                );  
+    };
+
+   /**
+     * Performs the checkout of the shopping basket.
+     *
+     * 
+     * The items in the shopping basket will be charged to the shopper.
+     * 
+     * Depending on the implementation of the actual payment service, this function
+     * might cause the checkout screen of the payment service provider to be displayed.
+     * 
+     */
+    ShoppingBasket.prototype.checkout = function (successCallback, errorCallback) {
+                var arguments = new Array();
+                arguments[0]=rpcServiceProviderID;
+                arguments[1]=rpcCustomerID;
+                arguments[2]=rpcShopID;
+                arguments[3]=this;
+                var self = this;
+                var rpc = webinos.rpcHandler.createRPC(this, "checkout", arguments);
+                webinos.rpcHandler.executeRPC(rpc,
+                                function (params){      
+                                        // remove shopping basket after checkout                                 
+                                              self=null;
+                                        successCallback();
+                                },
+                                function (error){errorCallback(error);}
+                );  
+    };
+
+ 
+
+    ShoppingBasket.prototype.release = function () {
+                var arguments = new Array();
+                arguments[0]=rpcServiceProviderID;
+                arguments[1]=rpcCustomerID;
+                arguments[2]=rpcShopID;
+                arguments[3]=this;
+                var self = this;
+    
+                 // now call thr release on the server, in case it needs to do some clean-up there                       
+                var rpc = webinos.rpcHandler.createRPC(this, "release", arguments);
+                webinos.rpcHandler.executeRPC(rpc,
+                                function (params){ },
+                                function (error){errorCallback(error);}
+                );  
+                 // remove shopping basket after release   
+                 // actually, we could do that without the RPC call,
+                 // but there might be data on the server side that
+                  // needs to be released as well.
+                     // would be best if we could null the object itself,
+                     // but JavaScript doesn't allow this               
+                                        self.items=null;
+                                        self.extras=null;        
+    };
+            
+}());

--- a/webinos/wrt/lib/webinos.servicedisco.js
+++ b/webinos/wrt/lib/webinos.servicedisco.js
@@ -1,56 +1,56 @@
 (function() {
-	
-	var isOnNode = function() {
-		return typeof module === "object" ? true : false;
-	};
+        
+        var isOnNode = function() {
+                return typeof module === "object" ? true : false;
+        };
     
     var ServiceDiscovery = function(rpcHandler) {
-    	this.rpcHandler = rpcHandler;
-    	this.registeredServices = 0;
-    	
-    	this._webinosReady = false;
-    	
-    	if (isOnNode()) {
-    		return;
-    	}
-    	// further code only runs in the browser
-    	
-    	var that = this;
-    	webinos.session.addListener('registeredBrowser', function() {
-    		that._webinosReady = true;
-    		
-    		finishCallers();
-    	});
+        this.rpcHandler = rpcHandler;
+        this.registeredServices = 0;
+        
+        this._webinosReady = false;
+        
+        if (isOnNode()) {
+                return;
+        }
+        // further code only runs in the browser
+        
+        var that = this;
+        webinos.session.addListener('registeredBrowser', function() {
+                that._webinosReady = true;
+                
+                finishCallers();
+        });
     };
     
-	/**
-	 * Export definitions for node.js
-	 */
-	if (isOnNode()) {
-		exports.ServiceDiscovery = ServiceDiscovery;
-	} else {
-		// this adds ServiceDiscovery to the window object in the browser
-		this.ServiceDiscovery = ServiceDiscovery;
-	}
-	
-	var callerCache = [];
-	
-	var finishCallers = function() {
-		for (var i = 0; i < callerCache.length; i++) {
-			var caller = callerCache[i];
-			webinos.discovery.findServices(caller.serviceType, caller.callback, caller.options, caller.filter);
-		}
-		callerCache = [];
-	}
-	
+        /**
+         * Export definitions for node.js
+         */
+        if (isOnNode()) {
+                exports.ServiceDiscovery = ServiceDiscovery;
+        } else {
+                // this adds ServiceDiscovery to the window object in the browser
+                this.ServiceDiscovery = ServiceDiscovery;
+        }
+        
+        var callerCache = [];
+        
+        var finishCallers = function() {
+                for (var i = 0; i < callerCache.length; i++) {
+                        var caller = callerCache[i];
+                        webinos.discovery.findServices(caller.serviceType, caller.callback, caller.options, caller.filter);
+                }
+                callerCache = [];
+        }
+        
     ServiceDiscovery.prototype.findServices = function (serviceType, callback, options, filter) {
-    	var that = this;
-    	
-    	if (!isOnNode() && !this._webinosReady) {
-    		callerCache.push({serviceType: serviceType, callback: callback, options: options, filter: filter});
-    		return;
-    	}
-    	
+        var that = this;
+        
+        if (!isOnNode() && !this._webinosReady) {
+                callerCache.push({serviceType: serviceType, callback: callback, options: options, filter: filter});
+                return;
+        }
+        
         // pure local services..
         if (serviceType == "BlobBuilder"){
             var tmp = new BlobBuilder();
@@ -78,7 +78,7 @@
                 typeMap['http://webinos.org/api/sensors'] = Sensor;
                 typeMap['http://webinos.org/api/sensors.temperature'] = Sensor;
             }                       
-            if (typeof PaymentManager !== 'undefined') typeMap['http://webinos.org/api/payment'] = PaymentManager;
+            if (typeof PaymentModule !== 'undefined') typeMap['http://webinos.org/api/payment'] = PaymentModule;
             if (typeof UserProfileIntModule !== 'undefined') typeMap['UserProfileInt'] = UserProfileIntModule;
             if (typeof TVManager !== 'undefined') typeMap['http://webinos.org/api/tv'] = TVManager;
             if (typeof DeviceStatusManager !== 'undefined') typeMap['http://wacapps.net/api/devicestatus'] = DeviceStatusManager;
@@ -89,19 +89,19 @@
             if (typeof AuthenticationModule !== 'undefined') typeMap['http://webinos.org/api/authentication'] = AuthenticationModule;
             
             if (isOnNode()) {
-            	var path = require('path');
-            	var moduleRoot = path.resolve(__dirname, '../') + '/';
-            	var moduleDependencies = require(moduleRoot + '/dependencies.json');
-            	var webinosRoot = path.resolve(moduleRoot + moduleDependencies.root.location) + '/';
-            	var dependencies = require(path.resolve(webinosRoot + '/dependencies.json'));
-            	
-            	var Context = require(path.join(webinosRoot, dependencies.wrt.location, 'lib/webinos.context.js')).Context;
+                var path = require('path');
+                var moduleRoot = path.resolve(__dirname, '../') + '/';
+                var moduleDependencies = require(moduleRoot + '/dependencies.json');
+                var webinosRoot = path.resolve(moduleRoot + moduleDependencies.root.location) + '/';
+                var dependencies = require(path.resolve(webinosRoot + '/dependencies.json'));
+                
+                var Context = require(path.join(webinosRoot, dependencies.wrt.location, 'lib/webinos.context.js')).Context;
                 typeMap['http://webinos.org/api/context'] = Context;
             }
 
             var ServiceConstructor = typeMap[baseServiceObj.api];
             if (typeof ServiceConstructor !== 'undefined') {
-            	// elevate baseServiceObj to usable local WebinosService object
+                // elevate baseServiceObj to usable local WebinosService object
                 var service = new ServiceConstructor(baseServiceObj, that.rpcHandler);
                 this.registeredServices++;
                 callback.onFound(service);
@@ -127,9 +127,9 @@
 
         var serviceAddress;
         if (typeof this.rpcHandler.parent !== 'undefined') {
-        	serviceAddress = this.rpcHandler.parent.config.pzhId;
+                serviceAddress = this.rpcHandler.parent.config.pzhId;
         } else {
-        	serviceAddress = webinos.session.getServiceLocation();
+                serviceAddress = webinos.session.getServiceLocation();
         }
         
         rpc.serviceAddress = serviceAddress;


### PR DESCRIPTION
```
Add payment testing to webinos and enable payment service again

This puts the payment service back into webinos - it was
commented out of the code for some reason and never moved
to the github repository.
Add missing file webinos.payment.js from ancient checkout and
update to current calling conventions.
Fix of package.json, which had wrong service name.
Add testing script for payment API.
Include payment in build and running control files.
```

http://jira.webinos.org/browse/WP-146
