### PR TITLE
Updated the Webinos-Platform version and added dependency

### DIFF
--- a/node_modules/webinos/README.md
+++ b/node_modules/webinos/README.md
@@ -1,0 +1,1 @@
+webinos module

--- a/package.json
+++ b/package.json
@@ -1,27 +1,28 @@
 {
   "name": "webinos_platform",
-  "description": "Web runtime platform based on Webinos specification",
-  "version": "0.0.1",
+  "description": "Web runtime platform based on webinos specification",
+  "version": "0.6.0",
   "dependencies": {
     "schema": "0.x.x",
     "sax": "0.x.x", 
     "seq": "0.x.x", 
     "xml2js": "0.x.x",
     "crypt": "0.0.x",
-    "ejs":"0.x.x",
-    "openid":"0.x.x",
-    "qrcode":"0.x.x",
-    "websocket":"1.0.2",
-    "vows":"0.x.x",
+    "ejs": "0.x.x",
+    "openid": "0.x.x",
+    "qrcode": "0.x.x",
+    "websocket": "1.0.2",
+    "vows": "0.x.x",
     "ansi": "0.0.x",
     "connect": "2.x.x",
     "mdns": "0.x.x",
     "jsormdb": "0.1.x",
-    "now": "0.8.1"
+    "now": "0.8.1",
+    "webinos": "0.x.x"
   },
   "engines" : {
-    "node" : ">=0.6.18",
-    "npm" : ">= 1.1.17"
+    "node": ">= 0.6.18",
+    "npm": ">= 1.1.17"
   },
   "keywords": ["webinos", "api"],
   "repository": "git://github.com/webinos/Webinos-Platform.git",


### PR DESCRIPTION
The resolution affects two files:

1) Modified:  Webinos-Platform/package.json
Added a dependency of
"webinos": "0.x.x"

This gets rid of the extraneous indication of the webinos module.

2) Newly added: Webinos-Platform/node_modules/webinos/README.md
The README.md file is a place-holder for further improvement.

This gets rid of the WARN: no README.md file found.

Jira Issue WP-199
