### PR TITLE
Wp 207 fix pzp startup on android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,33 +1,15 @@
+# generated webinos.js
+webinos/test/client/webinos.js
+
 # context db
 Manager/Context/Storage/data/context.json
 webinos/common/manager/context_manager/data/log.json
 
-# generated webinos.js
-webinos/test/client/webinos.js
-
-# eclipse project files
-.project
-.settings
-/.metadata/
-
-# vstudio prj files
-*.sln
-*.vcxproj*
-
-# generated certificates
-*.pem
-*.csr
-*.crl
-*.srl
-
-# backup files
-*~
-
-# waf lock files
-.lock-wscript
-
-# vi swap file
-*.swp
+# android generated build stuff
+webinos/common/android/*/bin/*
+webinos/common/android/*/gen/*
+webinos/common/android/app/assets/modules/webinos.zip
+webinos/common/android/wrt/assets/js/webinos.js
 
 # build stuff
 build
@@ -35,16 +17,11 @@ out
 *.node
 linker.lock
 *.o
+*.class
 
 # gyp generated
 webinos/common/manager/certificate_manager/src/Makefile
 webinos/common/manager/certificate_manager/src/*.mk
-
-# target folders
-target
-
-# reports folders
-reports
 
 # modules for vehicle connection
 webinos/api/vehicle/contrib/vb-con/
@@ -66,3 +43,34 @@ RPC/node_modules/xmlhttprequest/
 !/node_modules/xmldigsig.js
 
 webinos/api/geolocation/node_modules
+
+# generated certificates
+*.pem
+*.csr
+*.crl
+*.srl
+
+# target folders
+target
+
+# reports folders
+reports
+
+# eclipse project files
+.project
+.settings
+/.metadata/
+
+# vstudio prj files
+*.sln
+*.vcxproj*
+
+# waf lock files
+.lock-wscript
+
+# backup files
+*~
+
+# vi swap file
+*.swp
+

--- a/webinos/common/manager/context_manager/lib/storageCheck.js
+++ b/webinos/common/manager/context_manager/lib/storageCheck.js
@@ -98,29 +98,20 @@ function mkdirSyncRecursive(folderPath, position) {
 	var parts = path.resolve(folderPath).split(pathSeperator);
 
     position = position || 0;
-    
-  
-    if (position >= parts.length) {
-      return true;
-    }
-  
-    var directory = parts.slice(0, position + 1).join(pathSeperator) || pathSeperator;
-    try {
-      fs.statSync(directory);
-      mkdirSyncRecursive(folderPath, position + 1);
-    } catch (e) {
-//      try {
-        fs.mkdirSync(directory);
-        mkdirSyncRecursive(folderPath, position + 1);
-//      } catch (e) {
-//        if (e.errno != 17) {
-//          throw e;
-//        }
-//        mkdirSyncRecursive(folderPath, position + 1);
-//      }
-    }
-  }
 
+    if (position >= parts.length) {
+        return true;
+    }
+
+    var directory = parts.slice(0, position + 1).join(pathSeperator) || pathSeperator;
+    var stats = fs.statSync(directory);
+
+    if (!stats.isDirectory() && !stats.isFile()) {
+        fs.mkdirSync(directory);
+    }
+
+    mkdirSyncRecursive(folderPath, position + 1);
+}
 
 /*
  * based on: https://github.com/ryanmcgrath/wrench-js/

--- a/webinos/pzp/lib/pzp_sessionHandling.js
+++ b/webinos/pzp/lib/pzp_sessionHandling.js
@@ -71,9 +71,11 @@ if((os.type().toLowerCase() == "linux") && (os.platform().toLowerCase() == "andr
 {
 	// Console.log redefinition
 	console.log = function(dataLog) {
-		var id = fs.openSync("/sdcard/console.log", "a");
-		fs.writeSync(id, dataLog+"\n", null, 'utf8');
-		fs.closeSync(id);
+		fs.open("/sdcard/console.log", "a", function(err, fd) {
+			if (err) return; // no sdcard?
+			fs.writeSync(fd, dataLog+"\n", null, 'utf8');
+			fs.closeSync(fd);
+		});
 	}
 }
 


### PR DESCRIPTION
If the sdcard isn't available on Android the PZP will fail to start.
- Fix console.log implementation from the PZP that is only used on Android and assumes that the /sdcard path is always available.
- Fix context manager that fails to check if a directory exists before trying to create it.

http://jira.webinos.org/browse/WP-207
