### PR TITLE
Fix recusive path creation.

### DIFF
--- a/webinos/common/manager/context_manager/lib/storageCheck.js
+++ b/webinos/common/manager/context_manager/lib/storageCheck.js
@@ -104,12 +104,13 @@ function mkdirSyncRecursive(folderPath, position) {
     }
 
     var directory = parts.slice(0, position + 1).join(pathSeperator) || pathSeperator;
-    var stats = fs.statSync(directory);
-
-    if (!stats.isDirectory() && !stats.isFile()) {
-        fs.mkdirSync(directory);
+    if (!nPathV.existsSync(directory)) {
+        try {
+            fs.mkdirSync(directory);
+        } catch (e) {
+            return false; // could be permission error
+        }
     }
-
     mkdirSyncRecursive(folderPath, position + 1);
 }
 


### PR DESCRIPTION
Previous fix still caused problems sometimes. Use existsSync call
instead of calls to stats object which could throw error if path element
didn't exist. Should work on 0.6.x and 0.8.x now.

Jira-issue: WP-207
