### PR TITLE
Temp fix for node 0.9 disabled rejectUnauthorized

### DIFF
--- a/webinos/pzh/lib/pzh_connecting.js
+++ b/webinos/pzh/lib/pzh_connecting.js
@@ -181,6 +181,7 @@ PzhConnecting.prototype.sendCertificate = function(to, callback) {
   options.path   = "/main.html?cmd=transferCert";
   options.method = "POST";
   options.headers = { 'Content-Length': JSON.stringify(payload).length  };
+  options.rejectUnauthorized = false;
   
   var req = https.request(options, function(res) {
     res.on('data', function(data) {

--- a/webinos/pzh/web/pzh_webserver.js
+++ b/webinos/pzh/web/pzh_webserver.js
@@ -361,7 +361,8 @@ function createWebInterfaceCertificate (config, callback) {
                 var wss = {
                         key : ws_key,
                         cert: config.webServer.cert,
-                        ca  : config.master.cert
+                        ca  : config.master.cert,
+                        rejectUnauthorized: false
                 };
                 callback(wss);
               });

--- a/webinos/pzp/lib/pzp_websocket.js
+++ b/webinos/pzp/lib/pzp_websocket.js
@@ -296,6 +296,7 @@ function connectPzh(pzp, cmd, from, to, authCode) {
     port: global.port.farm_webServerPort,
     path: path,
     method: 'POST',
+    rejectUnauthorized: false,
     headers: {
       'Content-Length': JSON.stringify(payload).length
     }


### PR DESCRIPTION
Temporarily disabled rejectUnauthorized in https requests in order to allow connections with self signed certificates. Affected node version 0.9+

Jira issue: WP-396
http://jira.webinos.org/browse/WP-396
