### PR TITLE
Fix the licenses given in Certificate Manager and keystore

### DIFF
--- a/webinos/common/manager/certificate_manager/package.json
+++ b/webinos/common/manager/certificate_manager/package.json
@@ -9,9 +9,4 @@
   { "email": "john.lyle@cs.ox.ac.uk"
   , "url": "http://www.cs.ox.ac.uk/people/john.lyle"
   }
-, "licenses":
-  [ { "type": "MIT +no-false-attribs"
-    , "url": "http://github.com/isaacs/npm/raw/master/LICENSE"
-    }
-  ]
 }

--- a/webinos/common/manager/keystore/package.json
+++ b/webinos/common/manager/keystore/package.json
@@ -9,11 +9,6 @@
   { "email": "shamal.faily@cs.ox.ac.uk, habib.virji@samsung.com"
   , "url": "http://www.cs.ox.ac.uk/people/shamal.faily"
   }
-, "licenses":
-  [ { "type": "MIT +no-false-attribs"
-    , "url": "http://github.com/isaacs/npm/raw/master/LICENSE"
-    }
-  ]
 , "repositories": 
   [ { "type" : "git",
       "url"  : "http://dev.webinos.org/git/wp4.git"


### PR DESCRIPTION
http://jira.webinos.org/browse/WP-209

The package.json files in the certificate manager and keystore
were incorrectly stating an MIT license. I have removed them
in-line with all other package.json files.

Jira issue: WP-209
