### PR TITLE
Wp 405 unregister rpc callback obj

### DIFF
--- a/webinos/api/events/lib/events.js
+++ b/webinos/api/events/lib/events.js
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 * 
-* Copyright 2012 André Paul, Fraunhofer FOKUS
+* Copyright 2012 AndrÃ© Paul, Fraunhofer FOKUS
 ******************************************************************************/
 (function() {
 
@@ -41,7 +41,7 @@
 		 * @param errorCB Error callback.
 		 * @param objectRef RPC object reference.
 		 */
-		this.WebinosEvent.dispatchWebinosEvent = function (params, successCB, errorCB, objectRef){
+		this.WebinosEvent.dispatchWebinosEvent = function(params, successCB, errorCB, objectRef) {
 			//callbacks, referenceTimeout, sync
 			console.log("dispatchWebinosEvent was invoked: Payload: " + params.webinosevent.payload + " Type: " + params.webinosevent.type + " from: " + params.webinosevent.addressing.source.id);
 
@@ -82,24 +82,20 @@
 					}
 				}
 				
-				console.log("1");
 				//checking for recipient
 				if (typeof params.webinosevent.addressing.to !== 'undefined' && params.webinosevent.addressing.to.length > 0){
-					console.log("2");
 					for (j = 0; j < params.webinosevent.addressing.to.length; j++){
 						console.log("Listener Source: " + registeredListener[i].source + " addressing id: " + params.webinosevent.addressing.to[j].id);
 						
 						
 						if (registeredListener[i].source === params.webinosevent.addressing.to[j].id){
 							//	forward event
-								console.log("4");
 								foundDestination = true;
 								forwardEventMessage(registeredListener[i],params.webinosevent, params, useCB, rpcHandler, objectRef);
 						}
 						
 						if (!foundDestination && j != params.webinosevent.addressing.to.length-1){
 							foundDestination = true;
-							console.log("5");
 							var outCBParams = {};
 							outCBParams.event = params.webinosevent;
 							outCBParams.recipient = params.webinosevent.addressing.to[j].id
@@ -211,7 +207,7 @@
 	 * 
 	 * [not yet implemented]
 	 */
-	WebinosEventsModule.prototype.createWebinosEvent = function (params, successCB, errorCB, objectRef){
+	WebinosEventsModule.prototype.createWebinosEvent = function(params, successCB, errorCB, objectRef) {
 		console.log("createWebinosEvent was invoked");
 	};
 
@@ -220,7 +216,7 @@
 	 * @param params Object expecting type field.
 	 * @param ref Object expecting destination field.
 	 */
-	WebinosEventsModule.prototype.addWebinosEventListener = function (params, successCB, errorCB, objectRef){
+	WebinosEventsModule.prototype.addWebinosEventListener = function(params, successCB, errorCB, objectRef) {
 		
 		
 		console.log("addWebinosEventListener was invoked with params type: " + params.type + " source: " + params.source + " dest: " + params.destination);
@@ -248,7 +244,7 @@
 	 * 
 	 * [not yet implemented]
 	 */
-	WebinosEventsModule.prototype.removeWebinosEventListener = function (params, successCB, errorCB, objectRef){
+	WebinosEventsModule.prototype.removeWebinosEventListener = function(params, successCB, errorCB, objectRef) {
 		console.log("removeWebinosEventListener was invoked: " + params);
 		var idx = -1;
 		for (i = 0; i < registeredListener.length; i++){

--- a/webinos/test/spec/events/EventsSpec.js
+++ b/webinos/test/spec/events/EventsSpec.js
@@ -27,17 +27,23 @@ describe("Events API", function() {
 		});
 
 		webinos.discovery.findServices(new ServiceType("http://webinos.org/api/events"), {
-			onFound: function (service) {
-				eventsService = service;
+			onFound: function (unboundService) {
+				unboundService.bindService({onBind: function(service) {
+					eventsService = service;
+				}});
 			}
 		});
 
 		waitsFor(function() {
 			return !!eventsService;
-		}, "The discovery didn't find an Events service", 5000);
+		}, "Could not find or bind Events service", 5000);
 	});
 
-	it("should be available from the discovery", function() {
+	afterEach(function() {
+		eventsService = undefined;
+	});
+
+	it("could be found and be bound", function() {
 		expect(eventsService).toBeDefined();
 	});
 
@@ -49,23 +55,6 @@ describe("Events API", function() {
 		expect(eventsService.description).toEqual(jasmine.any(String));
 		expect(eventsService.icon).toEqual(jasmine.any(String));
 		expect(eventsService.bindService).toEqual(jasmine.any(Function));
-	});
-
-	it("can be bound", function() {
-		var bound = false;
-
-		eventsService.bindService({onBind: function(service) {
-			eventsService = service;
-			bound = true;
-		}});
-
-		waitsFor(function() {
-			return bound;
-		}, "The service couldn't be bound", 500);
-
-		runs(function() {
-			expect(bound).toEqual(true);
-		});
 	});
 
 	it("has the necessary properties and functions as Events API service", function() {
@@ -131,11 +120,12 @@ describe("Events API", function() {
 		}, "onDelivery callback to be called.", 3000);
 
 		runs(function() {
+			eventsService.removeWebinosEventListener(listenerId);
+
 			expect(sent).toEqual(true);
 			expect(delivered).toEqual(true);
 		});
 
-		eventsService.removeWebinosEventListener(listenerId);
 	});
 
 	it("can receive an event", function() {
@@ -156,10 +146,10 @@ describe("Events API", function() {
 		}, "event listener to be called.", 3000);
 
 		runs(function() {
+			eventsService.removeWebinosEventListener(listenerId);
+
 			expect(received).toEqual(true);
 		});
-
-		eventsService.removeWebinosEventListener(listenerId);
 	});
 
 });

--- a/webinos/wrt/lib/webinos.events.js
+++ b/webinos/wrt/lib/webinos.events.js
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 * 
-* Copyright 2012 André Paul, Fraunhofer FOKUS
+* Copyright 2012 AndrÃ© Paul, Fraunhofer FOKUS
 ******************************************************************************/
 (function() {
 
@@ -23,7 +23,7 @@
 	var registeredDispatchListeners = {};
 	
 	var eventService = null;
-	
+
 	/**
 	 * Webinos Event service constructor (client side).
 	 * @constructor
@@ -35,14 +35,14 @@
 		eventService = this;
 		this.idCount = 0;
 		//this.myAppID = "TestApp" + webinos.messageHandler.getOwnId();
-		
+
 		//TODO, this is the actuall messaging/session app id but should be replaced with the Apps unique ID (config.xml)
 		this.myAppID = webinos.messageHandler.getOwnId();
 		console.log("MyAppID: " + this.myAppID);
 	};
-	
+
 	EventsModule.prototype = new WebinosService;
-	
+
 	/**
 	 * To bind the service.
 	 * @param bindCB BindCallback object.
@@ -53,8 +53,8 @@
 			bindCB.onBind(this);
 		};
 		
-	}
-	
+	};
+
 	/**
 	 * Creates a webinos Event.
 	 * @param type Event type identifier.
@@ -75,22 +75,13 @@
 		anEvent.timeStamp = new Date().getTime();
 		anEvent.expiryTimeStamp = expiryTimeStamp;
 		anEvent.addressingSensitive = addressingSensitive;
-		
-		
-		return anEvent;
-		/*
-		var rpc = webinos.rpcHandler.createRPC(this, "createWebinosEvent",  arguments);
-		webinos.rpcHandler.executeRPC(rpc,
-				function (params){
-					successCB(params);
-				},
-				function (error){}
-		);*/	
-		
+
+
+		//  raises(WebinosEventException);
 		//	returns WebinosEvent
-        //  raises(WebinosEventException);
-	}
-    
+		return anEvent;
+	};
+
 	/**
 	 * Registers an event listener.
 	 * @param listener The event listener.
@@ -99,62 +90,52 @@
 	 * @param destination Specific event recipient (whether primary or not) or null for any destination (undefined is considered as null).
 	 * @returns Listener identifier.
 	 */
-	EventsModule.prototype.addWebinosEventListener = function(listener, type, source, destination){
-		
-		
-		if (this.idCount == Number.MAX_VALUE) this.idCount = 0;
+	EventsModule.prototype.addWebinosEventListener = function(listener, type, source, destination) {
+
+		if (this.idCount === Number.MAX_VALUE) this.idCount = 0;
 		this.idCount++;
-				
-		var listenerID = this.myAppID + ":" + this.idCount;
-		
-		
-		var req = {};
-		req.type = type;
-		req.source = source;
-		
-		if (typeof req.source === 'undefined' || req.source == null) req.source = this.myAppID;
-		
-		
-		req.destination = destination;
-		
-		
-		
-		var rpc = webinos.rpcHandler.createRPC(this, "addWebinosEventListener",  req);
-		
-		rpc.handleEvent = function (params,scb,ecb) {
+
+		var listenerId = this.myAppID + ":" + this.idCount;
+
+		var reqParams = {
+			type: type,
+			source: source,
+			destination: destination
+		};
+		if (!source) reqParams.source = this.myAppID;
+
+		var rpc = webinos.rpcHandler.createRPC(this, "addWebinosEventListener",  reqParams);
+
+		rpc.handleEvent = function(params, scb, ecb) {
 			console.log("Received a new WebinosEvent");
 			listener(params.webinosevent);
 			scb();
 		};
-		
+
 		webinos.rpcHandler.registerCallbackObject(rpc);
 		
 		
 		
 		webinos.rpcHandler.executeRPC(rpc,
-				function (params){
-					console.log("New WebinosEvent listener registered. Mapping remote ID", params, " localID ", listenerID);
-					
-					registeredListeners[listenerID] = params;
-					
-				},
-				function (error){
-					console.log("Error while registering new WebinosEvent listener");
-				}
+			function(remoteId) {
+				console.log("New WebinosEvent listener registered. Mapping remote ID", remoteId, " localID ", listenerId);
+
+				registeredListeners[listenerId] = remoteId;
+			},
+			function(error) {
+				console.log("Error while registering new WebinosEvent listener");
+			}
 		);
-		
-		// returns DOMString id
+
 		// raises(WebinosEventException);
-		
-		return listenerID;
-	}
-                         
-    /**
+		return listenerId;
+	};
+
+	/**
      * Unregisters an event listener.
      * @param listenerId Listener identifier as returned by addWebinosEventListener().
      */
-	EventsModule.prototype.removeWebinosEventListener = function(listenerId){
-	 
+	EventsModule.prototype.removeWebinosEventListener = function(listenerId) {
 		var rpc = webinos.rpcHandler.createRPC(this, "removeWebinosEventListener",  registeredListeners[listenerId]);
 		webinos.rpcHandler.executeRPC(rpc,
 				function (params){
@@ -165,11 +146,7 @@
 	 
 		// raises(WebinosEventException);
 		// returns void
-	}
-	
-	
-	// WebinosEvent functionalities
-	
+	};
 	/**
 	 * Webinos Event constructor.
 	 * @constructor
@@ -250,31 +227,24 @@
 			//params.event, params.recipient, params.error
 				if (typeof callbacks.onError !== "undefined") {callbacks.onError(params.event, params.recipient, params.error);}
 			};
-	
-		
+
 			webinos.rpcHandler.registerCallbackObject(rpc);
 		}
-		
+
 		webinos.rpcHandler.executeRPC(rpc);
-		
-		
-		//rpc.serviceAddress = webinos.session.getPZHId();
-		//webinos.rpcHandler.executeRPC(rpc);
-    	
-		
+
+		//raises(WebinosEventException);
 		//returns void
-    	//raises(WebinosEventException);
-         
-    }
-    
+    };
+
 	/**
 	 * Forwards an event.
 	 * [not yet implemented]
 	 */
 	WebinosEvent.prototype.forwardWebinosEvent = function(forwarding, withTimeStamp, callbacks, referenceTimeout, sync){
-    	
+
     	//returns void
     	//raises(WebinosEventException);
     };
-	
+
 }());

--- a/webinos/wrt/lib/webinos.events.js
+++ b/webinos/wrt/lib/webinos.events.js
@@ -229,6 +229,7 @@
 					throw new WebinosEventException(WebinosEventException.INVALID_ARGUMENT_ERROR, "cb is not a function");
 				}
 			}
+			params.withCallbacks = true;
 		}
 
 		var rpc = webinos.rpcHandler.createRPC(eventService, "WebinosEvent.dispatchWebinosEvent", params);


### PR DESCRIPTION
Part of the fix for WP-405. Call unregisterCallbackObject for RPC objects in removeWebinosEventListener
and dispatchWebinosEvent when they aren't used anymore.

http://jira.webinos.org/browse/WP-405
