### PR TITLE
WP-431: Update package.json to give node-uuid version "1.3.x"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   , "mdns" : "0.x.x"
   , "jsormdb" : "0.1.x"
   , "now" : "0.8.1"
-  , "node-uuid" : "0.3.x"
+  , "node-uuid" : "1.3.x"
   , "find-dependencies" : "0.0.x"
   , "inherits" : "1.0.0"
   , "mkdirp" : "0.3.x"


### PR DESCRIPTION
JIRA issue WP-431

http://jira.webinos.org/browse/WP-431

node-uuid "0.3.x" seems to have been removed, this commit simply updates to 1.3.x
