### PR TITLE
Don't call posix methods on Windows

### DIFF
--- a/webinos/common/util/lib/logging.js
+++ b/webinos/common/util/lib/logging.js
@@ -84,8 +84,10 @@ var Log = function(filename) {
     var self = this;
     if (instanceName !== "" && (this.writeError === "" || this.writeInfo === "")){
       if (os.platform().toLowerCase() !== "android"){
-        fs.chown(wPath.webinosPath()+"/logs/", process.getuid(), process.getgid());
-        fs.chmod(wPath.webinosPath()+"/logs/",0777);
+        if (process.getuid) {
+          fs.chown(wPath.webinosPath()+"/logs/", process.getuid(), process.getgid());
+          fs.chmod(wPath.webinosPath()+"/logs/", 0777);
+        }
       }
       var filename = path.join(wPath.webinosPath()+"/logs/", instanceName+"_"+type+".json");
       try{

--- a/webinos/pzp/lib/session_configuration.js
+++ b/webinos/pzp/lib/session_configuration.js
@@ -310,8 +310,10 @@ Config.prototype.createDirectories = function(callback) {
   try {
     fs.mkdir(wPath.webinosPath(),permission,function(err){});
     if (os.platform().toLowerCase() !== "android"){
-      fs.chown(wPath.webinosPath(), process.getuid(), process.getgid());
-      fs.chmod(wPath.webinosPath(),permission);
+      if (process.getuid) {
+        fs.chown(wPath.webinosPath(), process.getuid(), process.getgid());
+        fs.chmod(wPath.webinosPath(), permission);
+      }
     }
     setTimeout(function(){ // to wait for .webinos creation
      fs.mkdir(self.metaData.webinosRoot, permission, function(err){


### PR DESCRIPTION
chmod, chown, getuid, getgid don't exist on Windows, so only use them
on POSIX systems.

Jira-issue: http://jira.webinos.org/browse/WP-212
