### PR TITLE
Widget does not run immediately after installation

### DIFF
--- a/webinos/common/manager/widget_manager/lib/model/zipwidgetresource.js
+++ b/webinos/common/manager/widget_manager/lib/model/zipwidgetresource.js
@@ -64,7 +64,12 @@ this.ZipWidgetResource = (function() {
   };
 
   ZipWidgetResource.prototype.dispose = function() {
-    this.zipfile.destroy();
+    try {
+      this.zipfile.destroy();
+    } catch (e) {
+      console.log("ZipWidgetResource.dispose - " + e.message);
+    }
+    this.zipfile = null;
   };
 
   return ZipWidgetResource;


### PR DESCRIPTION
Linux version of zipfile module does not currently have a destroy method, this causes a crash during finalisation of widget installation.

http://jira.webinos.org/browse/WP-432
