### PR TITLE
Jira issue WP-456: Reorder creation of platform socket object and script injection

### DIFF
--- a/webinos/common/android/wrt/src/org/webinos/wrt/renderer/WebView.java
+++ b/webinos/common/android/wrt/src/org/webinos/wrt/renderer/WebView.java
@@ -1,36 +1,43 @@
 /*******************************************************************************
-*  Code contributed to the webinos project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* Copyright 2011-2012 Paddy Byers
-*
-******************************************************************************/
+ *  Code contributed to the webinos project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2011-2012 Paddy Byers
+ *
+ ******************************************************************************/
 
 package org.webinos.wrt.renderer;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.util.Log;
 
+@SuppressLint("SetJavaScriptEnabled")
 public class WebView extends android.webkit.WebView {
 
+	private static final String TAG = "org.webinos.wrt.renderer.WebView";
 	public WebView(Context context, AttributeSet as) {
 		super(context, as);
 		getSettings().setJavaScriptEnabled(true);
+		/* TO avoid the scrollbar issue
+		 * http://forum.jquery.com/topic/extra-vertical-white-space-at-right-on-screen-for-android-phone */
+		setScrollBarStyle(WebView.SCROLLBARS_OUTSIDE_OVERLAY);
 	}
 
 	public void injectScript(String script) {
+		Log.i(TAG,"inject script called:"+ script);
 		try {
 			String functionBody = "var s=document.createElement('script');"
 					+ "s.text=" + script + ";"
@@ -39,31 +46,22 @@ public class WebView extends android.webkit.WebView {
 					+ "console.log('injected script');";
 			loadUrl("javascript:(function(){" + functionBody + "})()");
 		} catch (Throwable t) {
-			Log.v("org.webinos.wrt.renderer.WebView",
-					"Error in injecting script", t);
+			Log.e(TAG, "Error in injecting script", t);
 		}
 	}
 
 	public void injectScripts(String[] scripts) {
+		Log.i(TAG,"inject scripts called");
 		try {
-			String functionBody = "var target = document.getElementsByTagName('head')[0] || document.firstChild || document;"
-					+ "var child = target.firstChild;"
-					+ "console.log('target = ' + target + ', document = ' + document + ', head = ' + document.head + ', child = ' + child);"
-					+ "var insert = child ? function(x){target.insertBefore(x, child);} : function(x){target.appendChild(x);};";
-			for (String script : scripts) {
-				functionBody += "var s=document.createElement('script');"
-						+ "s.text=" + script + ";"
-						+ "console.log('injecting script...');" + "insert(s);"
-						+ "console.log('injected script');" + "";
-			}
-			loadUrl("javascript:(function(){" + functionBody + "})()");
+			for (String script : scripts)
+				loadUrl("javascript:(function(){" + script + "})()");
 		} catch (Throwable t) {
-			Log.v("org.webinos.wrt.renderer.WebView",
-					"Error in injecting script", t);
+			Log.e(TAG, "Error in injecting script", t);
 		}
 	}
 
 	public void callScript(final String script) {
+		Log.i(TAG,"call script called:" + script);
 		Log.v("org.webinos.wrt.renderer.WebView.callScript()", script);
 		try {
 			getHandler().post(new Runnable() {
@@ -72,8 +70,7 @@ public class WebView extends android.webkit.WebView {
 				}
 			});
 		} catch (Throwable t) {
-			Log.v("org.webinos.wrt.renderer.WebView",
-					"Error in JavaScript callback", t);
+			Log.e(TAG, "Error in JavaScript callback", t);
 		}
 	}
 }

--- a/webinos/common/android/wrt/src/org/webinos/wrt/renderer/WebViewClient.java
+++ b/webinos/common/android/wrt/src/org/webinos/wrt/renderer/WebViewClient.java
@@ -1,21 +1,21 @@
 /*******************************************************************************
-*  Code contributed to the webinos project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* Copyright 2011-2012 Paddy Byers
-*
-******************************************************************************/
+ *  Code contributed to the webinos project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2011-2012 Paddy Byers
+ *
+ ******************************************************************************/
 
 package org.webinos.wrt.renderer;
 
@@ -42,14 +42,13 @@ public class WebViewClient extends android.webkit.WebViewClient {
 	@Override
 	public void onPageStarted(android.webkit.WebView webView, String url,
 			Bitmap favicon) {
+		Log.v(TAG,"onPage started called");
+		super.onPageStarted(webView, url, favicon);
 		WebView wgtView = (WebView) webView;
-		webView.addJavascriptInterface(activity.getClientSocket(), "__webinos");
 		try {
 			wgtView.injectScripts(new String[] {
 					AssetUtils.getAssetAsString(WrtManager.getInstance(),
-							ClientSocket.SOCKETJS_ASSET),
-					AssetUtils.getAssetAsString(WrtManager.getInstance(),
-							ClientSocket.WEBINOSJS_ASSET) });
+							ClientSocket.SOCKETJS_ASSET)});
 		} catch (IOException ioe) {
 			Log.v(TAG, "Unable to inject scripts; exception: ", ioe);
 		}
@@ -57,5 +56,16 @@ public class WebViewClient extends android.webkit.WebViewClient {
 
 	@Override
 	public void onPageFinished(android.webkit.WebView webView, String url) {
+		super.onPageFinished(webView, url);
+		Log.v(TAG,"onPage finished called");
+		/* TEMPORARILY disabled - webinos.js is no too long to go in a String (!)
+		WebView wgtView = (WebView) webView;
+		try {
+			wgtView.injectScripts(new String[] {
+					AssetUtils.getAssetAsString(WrtManager.getInstance(),
+							ClientSocket.WEBINOSJS_ASSET), "alert('Injected webinos');" });
+		} catch (IOException ioe) {
+			Log.v(TAG, "Unable to inject scripts; exception: ", ioe);
+		} */
 	}
 }

--- a/webinos/common/android/wrt/src/org/webinos/wrt/ui/RendererActivity.java
+++ b/webinos/common/android/wrt/src/org/webinos/wrt/ui/RendererActivity.java
@@ -1,21 +1,21 @@
 /*******************************************************************************
-*  Code contributed to the webinos project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* Copyright 2011-2012 Paddy Byers
-*
-******************************************************************************/
+ *  Code contributed to the webinos project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2011-2012 Paddy Byers
+ *
+ ******************************************************************************/
 
 package org.webinos.wrt.ui;
 
@@ -78,6 +78,9 @@ public class RendererActivity extends Activity implements WrtManager.LaunchListe
 		webView.setWebViewClient(new WebViewClient(this));
 		webView.setWebChromeClient(new WebChromeClient(this));
 		socket = new ClientSocket(webView, widgetConfig, instanceId);
+		/* Inject the socket object */
+		webView.addJavascriptInterface(socket, "__webinos");
+		/* Load the widget start document */
 		webView.loadUrl(widgetConfig.getStartUrl());		
 
 		WrtManager.getInstance().put(instanceId, this);


### PR DESCRIPTION
Jira issue: WP-456

The addition of the WebinosSocket object is moved to be prior to
page loading, and the injection of the associated script is moved
to the start of page loading.

In this revision, the injection of the webinos.js script is
temporarily disabled, since the existing mechanism is limited
to strings of length 65535 chars (and webinos.js is now too long).
