### PR TITLE
pzp locates the default policy.xml file

### DIFF
--- a/webinos/pzp/lib/session_configuration.js
+++ b/webinos/pzp/lib/session_configuration.js
@@ -350,7 +350,7 @@ Config.prototype.createPolicyFile = function(self) {
     if ( err && err.code=== "ENOENT" ) {
       var data;
       try {
-        data = fs.readFileSync("./webinos/common/manager/policy_manager/defaultpolicy.xml");
+        data = fs.readFileSync(path.resolve(__dirname, "../../common/manager/policy_manager/defaultpolicy.xml"));
       }
       catch(e) {
         logger.error("Default policy non found");


### PR DESCRIPTION
There was an error on android and couldn't locate the defaultpolicy.xml file. Thus added the deny all default policy and no api call could pass through.

Jira issue: WP-479
