### PR TITLE
Fixed dummy api's that should not register

### DIFF
--- a/webinos/api/zap-and-shake/zap-and-shake.js
+++ b/webinos/api/zap-and-shake/zap-and-shake.js
@@ -55,5 +55,5 @@ server.on("error", function (error) {
 })
 server.listen(port)
 
-//Expose an empty service to avoid the error
-exports.Service = function(){};
+//Expose an empty service
+exports.Service = null;

--- a/webinos/common/rpc/lib/registry.js
+++ b/webinos/common/rpc/lib/registry.js
@@ -164,6 +164,7 @@
 		for (var i = 0; i < services.length; i++){
 			try {
 				var Service = services[i];
+                if (typeof Service === "function") //Some modules are just modification and do not expose any real API function
 				_registerObject.call(this, new Service(rpcHandler, modules[i].params));
 			}catch (error){
 				logger.error(error);


### PR DESCRIPTION
zap-and-shake module doesn't expose any service so the pzp doesn't add it in it's list.

Jira issue: WP-482
