### PR TITLE
WP-491 Provide the current websocket port to the client

### DIFF
--- a/webinos/common/manager/widget_manager/lib/ui/routes/settings.js
+++ b/webinos/common/manager/widget_manager/lib/ui/routes/settings.js
@@ -47,6 +47,24 @@
       });
     }
 
+    /**
+     * Expose the current communication channel websocket port.
+     * Check the usage in widgetServer.js for more info.
+     *
+     * @param req
+     * @param res
+     */
+    exports.getWebinosConfig = function (req, res) {
+        readWRTConfig(function(cnf){
+            var jsonReply = {
+                websocketPort : cnf.pzpWebSocketPort
+            };
+            res.writeHead(200, {"Content-Type": "application/json"});
+            res.write(JSON.stringify(jsonReply));
+            res.end();
+        });
+    };
+
     exports.setWRTPort = function (port) {
         wrtPort = port;
     };

--- a/webinos/common/manager/widget_manager/lib/ui/widgetServer.js
+++ b/webinos/common/manager/widget_manager/lib/ui/widgetServer.js
@@ -31,6 +31,13 @@
     var settings = require('./routes/settings');
     var widgetTests = require('./routes/widgetTests');
 
+      /**
+       * Expose the current communication channel websocket port using this virtual file.
+       * This code must have the same result with the handleRequest on the pzp_websocket.js
+       * webinos\pzp\lib\pzp_websocket.js
+       */
+      app.get('/webinosConfig.json', settings.getWebinosConfig);
+
     // apps routing
     app.get('/', apps.installed);
     app.get('/apps', apps.installed);

--- a/webinos/pzp/lib/pzp_websocket.js
+++ b/webinos/pzp/lib/pzp_websocket.js
@@ -103,6 +103,24 @@ var PzpWSS = function() {
     }
   }
   function handleRequest(uri, req, res) {
+      /**
+       * Expose the current communication channel websocket port using this virtual file.
+       * This code must have the same result with the widgetServer.js used by wrt
+       * webinos\common\manager\widget_manager\lib\ui\widgetServer.js
+       */
+      if (uri == "/webinosConfig.json"){
+          var jsonReply = {
+              websocketPort : ports.pzp_webSocket
+          };
+          res.writeHead(200, {"Content-Type": "application/json"});
+          res.write(JSON.stringify(jsonReply));
+          res.end();
+          return;
+      }
+
+      //TODO: Fix this. This is exploitable...
+      // telenet the localhost 8080 and write GET /../../webinos_config.json
+      // you will get the contents in plain text
     var filename = path.join(__dirname, "../../test/", uri);
 
     fs.stat(filename, function(err, stats) {


### PR DESCRIPTION
exposed the websocket port from both pzp webserver and express server used by wrt.
On the client side, i try to get that from the server and apply some mechanism to try and guess it, just in case the script is not loaded properly (aka directly from local file or non webinos webserver).

Jira issue: WP-491
