### PR TITLE
Use path.existsSync for node 0.6

### DIFF
--- a/webinos/pzp/lib/session_configuration.js
+++ b/webinos/pzp/lib/session_configuration.js
@@ -308,6 +308,8 @@ Config.prototype.fetchUserPref = function (callback) {
 Config.prototype.createDirectories = function (callback) {
     var self = this, dirPath, permission = 0777;
     try {
+        //In case of node 0.6, define the fs existsSync
+        if (typeof fs.existsSync === "undefined") fs.existsSync = path.existsSync;
         if (!fs.existsSync(wPath.webinosPath()))//If the folder doesn't exist
             fs.mkdirSync(wPath.webinosPath(), permission);//Create it
         //Set permissions for android


### PR DESCRIPTION
Fixed the check to support node 0.6 too

Jira Issue WP-495
