### PR TITLE
Update jquery version for api tests

### DIFF
--- a/webinos/test/apiTests.html
+++ b/webinos/test/apiTests.html
@@ -14,7 +14,7 @@
         .unimplemented { background-color: Red; }
         .key { display: inline-block; width: 20px; }
     </style>
-    <script type="text/javascript" src="client/jquery-1.7.2.min.js"></script>
+    <script type="text/javascript" src="client/jquery-1.8.2.min.js"></script>
     <script type="text/javascript" src="client/webinos.js"></script>
     <script type="text/javascript">
         $(function () {


### PR DESCRIPTION
The local jquery version has been changed to 1.8.2, apiTests.html was referencing 1.7.2, causing a 404 error.

http://jira.webinos.org/browse/WP-496
