### PR TITLE
Do not register callback rpc objects in registry

### DIFF
--- a/webinos/common/rpc/lib/registry.js
+++ b/webinos/common/rpc/lib/registry.js
@@ -88,24 +88,6 @@
 	};
 
 	/**
-	 * Registers an object as RPC request receiver.
-	 * @param callback The callback object that contains the methods available via RPC.
-	 */
-	Registry.prototype.registerCallbackObject = function (callback) {
-		if (!callback) {
-			return;
-		}
-		logger.log("Adding: " + callback.api);
-
-		var receiverObjs = this.objects[callback.api];
-		if (!receiverObjs)
-			receiverObjs = [];
-
-		receiverObjs.push(callback);
-		this.objects[callback.api] = receiverObjs;
-	};
-
-	/**
 	 * Unregisters an object, so it can no longer receives requests.
 	 * @param callback The callback object to unregister.
 	 */


### PR DESCRIPTION
Instead register them inside the rpcHandler. RPC supports two
different type of requests. 1) Normal requests to services registered in
the registry. 2) Requests to callback objects that function as replies to
an initial request from that callback object. These callback objects are
registered with registerCallbackObject method.

This change makes sure the callback objects don't pollute the registry.
Services from the registry need to be communicated to other entities in
the PZ. While callback objects are completely private to an entity, so
information about them should never be sent anywhere.

Jira-issue: http://jira.webinos.org/browse/WP-513
