### PR TITLE
WP-129: Shorter authentication code

### DIFF
--- a/webinos/pzh/lib/pzh_authcode.js
+++ b/webinos/pzh/lib/pzh_authcode.js
@@ -94,6 +94,7 @@ tokenAuth.createAuthCounter = function(callback) {
      */
   authCounter.isExpectedCode = function(newcode, cb) {
     var self = this;
+    newcode = newcode.toUpperCase();
 
     logger.log("trying to add a PZP, code: " + newcode);
 

--- a/webinos/pzh/lib/pzh_qrcode.js
+++ b/webinos/pzh/lib/pzh_qrcode.js
@@ -42,7 +42,7 @@ function create(url, code, cb) {
 
 function generateRandomCode() {
   "use strict";
-  return crypto.randomBytes(8).toString("base64");
+  return crypto.randomBytes(3).toString("hex").toUpperCase();
 }
 
 // Generate me a random code.  I do hope this is secure...

--- a/webinos/pzh/web/css/layout.css
+++ b/webinos/pzh/web/css/layout.css
@@ -367,3 +367,9 @@ width: 66%;
 margin-right: 0;
 float: left;
 }
+
+.authCode {
+    font-family: "Lucida Console", Monaco, "Courier New", Courier, monospace;
+    font-size: 18px;
+}
+

--- a/webinos/pzh/web/main.html
+++ b/webinos/pzh/web/main.html
@@ -35,7 +35,7 @@
   function displayQRCode(payload){
       var text = "<center>";
       text += "<p> <img src=" + payload.img + "> </img> </p> ";
-      text += "<p> <h2>" +payload.code +"</h2> </p>";
+      text += "<p> <h2 class='authCode'>" +payload.code +"</h2> </p>";
       text += "<p>This temporary access code can be used to add a new device to your personal zone.</p>";
       setArticle("Temporary access code",text);
   }

--- a/webinos_pzp.js
+++ b/webinos_pzp.js
@@ -54,7 +54,7 @@ process.argv.forEach(function (arg) {
         options.preference = parts[1];
         break;
       case "--auth-code":
-        options.code = parts[1]+"="; // added as last letter in qrcode is = but above "split" removes this info
+        options.code = parts[1];
         break;
       default:
         console.log("unknown option: " + parts[0]);


### PR DESCRIPTION
http://jira.webinos.org/browse/WP-129

The authentication code is now smaller (3 not 8 bytes) and is
in HEX not BASE64. This makes it easier to input on constrained
devices.

The code is now case-insensitive (always upper case) and the
webinos_pzp script will no longer append '=' to the end of it.

Jira issue: WP-129
