### PR TITLE
WP-329: Disallow non-localhost origins to perform autoenrolment

### DIFF
--- a/webinos/pzp/lib/pzp_websocket.js
+++ b/webinos/pzp/lib/pzp_websocket.js
@@ -103,20 +103,7 @@ var PzpWSS = function() {
     }
   }
   function handleRequest(uri, req, res) {
-    /**
-     * Expose the current communication channel websocket port using this virtual file.
-     * This code must have the same result with the widgetServer.js used by wrt
-     * webinos\common\manager\widget_manager\lib\ui\widgetServer.js
-     */
-    if (uri == "/webinosConfig.json"){
-      var jsonReply = {
-        websocketPort : ports.pzp_webSocket
-      };
-      res.writeHead(200, {"Content-Type": "application/json"});
-      res.write(JSON.stringify(jsonReply));
-      res.end();
-      return;
-    }
+    var filename = path.join(__dirname, "../../test/", uri);
 
     var documentRoot = path.join(__dirname, "../../test/");
     var filename = path.join(documentRoot, uri);


### PR DESCRIPTION
The PZP will now check for websocket connections to make sure:

(1) They come from localhost
(2) That if they attempt to do autoenrolment, their origin hostname
is 'localhost' or '127.0.0.1'.

This is a quick fix to WP-329 and fixes indentation.

Jira issue: WP-329
