### PR TITLE
WP-329: Disallow non-localhost origins to perform autoenrolment

### DIFF
--- a/webinos/pzp/lib/pzp_websocket.js
+++ b/webinos/pzp/lib/pzp_websocket.js
@@ -1,62 +1,66 @@
 /*******************************************************************************
-*  Code contributed to the webinos project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* Copyright 2011 Habib Virji, Samsung Electronics (UK) Ltd
-*******************************************************************************/
-
+ *  Code contributed to the webinos project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2011 Habib Virji, Samsung Electronics (UK) Ltd
+ *******************************************************************************/
 var http = require("http"),
-  url    = require("url"),
-  path   = require("path"),
-  util   = require("util"),
-  fs     = require("fs"),
-  https  = require('https'),
+  url = require("url"),
+  path = require("path"),
+  util = require("util"),
+  fs = require("fs"),
+  https = require('https'),
   WebSocketServer = require("websocket").server,
-  session         = require("./session") ;
+  session = require("./session");
 
 var webinos = require("find-dependencies")(__dirname);
-var logger  = webinos.global.require(webinos.global.util.location, "lib/logging.js")(__filename) || console;
+var logger = webinos.global.require(webinos.global.util.location, "lib/logging.js")(__filename) || console;
 var content = webinos.global.require(webinos.global.util.location, "lib/content.js");
 
 var wrtServer;
 
-if(process.platform == "android") {
+if (process.platform == "android") {
   try {
     wrtServer = require("bridge").load("org.webinos.app.wrt.channel.WebinosSocketServerImpl", exports);
-  } catch(e) {
+  } catch (e) {
     logger.error("exception attempting to open wrt server " + e);
   }
 }
-var PzpWSS = function() {
+var PzpWSS = function () {
   "use strict";
   var connectedWebApp = {}; // List of connected apps i.e session with browser
-  var sessionWebApp   = 0;
-  var wsServer        = "";
+  var sessionWebApp = 0;
+  var wsServer = "";
   var sessionId;
   var pzhId;
   var ports = {};
   var address;
   var csr;
-  var self            = this;
+  var self = this;
 
   function prepMsg(from, to, status, message) {
-    return {"type" : "prop",
-      "from" : from,
-      "to"   : to,
-      "payload":{"status":status,
-        "message":message}};
+    return {
+      "type": "prop",
+        "from": from,
+        "to": to,
+        "payload": {
+        "status": status,
+          "message": message
+      }
+    };
   }
+
   function wsServerMsg(message) {
     for (var key in connectedWebApp) {
       if (connectedWebApp.hasOwnProperty(key) && connectedWebApp[key].status === "") {
@@ -65,7 +69,8 @@ var PzpWSS = function() {
       }
     }
   }
-  function wsMessage(connection, utf8Data) {
+
+  function wsMessage(connection, origin, utf8Data) {
     //schema validation
     var msg = JSON.parse(utf8Data);
     var invalidSchemaCheck = true;
@@ -74,93 +79,83 @@ var PzpWSS = function() {
     } catch (err) {
       logger.error(err);
     }
-    if(invalidSchemaCheck) {
+    if (invalidSchemaCheck) {
       // For debug purposes, we only print a message about unrecognized packet,
       // in the final version we should throw an error.
       // Currently there is no a formal list of allowed packages and throw errors
       // would prevent the PZP from working
       logger.error("msg schema is not valid " + JSON.stringify(msg));
-    }
-    else {
+    } else {
       // schema check is false, so validation is ok
       //log("DEBUG",  "[PZP WSServer]: msg schema is valid " + JSON.stringify(msg));
     }
     // Each message is forwarded back to Message Handler to forward rpc message
-    if(msg.type === "prop" ) {
-      if(msg.payload.status === "registerBrowser") {
+    if (msg.type === "prop") {
+      if (msg.payload.status === "registerBrowser") {
         connectedApp(connection);
       } else {
-        autoEnrollment(msg);
+        autoEnrollment(msg, origin);
       }
     } else {
       self.messageHandler.onMessageReceived(msg, msg.to);
     }
   }
+
   function wsClose(connection, reason) {
     if (connectedWebApp[connection.id]) {
       delete connectedWebApp[connection.id];
       logger.log("web client disconnected: " + connection.id + " due to " + reason);
     }
   }
+
   function handleRequest(uri, req, res) {
-    /**
-     * Expose the current communication channel websocket port using this virtual file.
-     * This code must have the same result with the widgetServer.js used by wrt
-     * webinos\common\manager\widget_manager\lib\ui\widgetServer.js
-     */
-    if (uri == "/webinosConfig.json"){
-      var jsonReply = {
-        websocketPort : ports.pzp_webSocket
-      };
-      res.writeHead(200, {"Content-Type": "application/json"});
-      res.write(JSON.stringify(jsonReply));
-      res.end();
-      return;
-    }
+    var filename = path.join(__dirname, "../../test/", uri);
 
     var documentRoot = path.join(__dirname, "../../test/");
     var filename = path.join(documentRoot, uri);
 
     content.sendFile(res, documentRoot, filename, "client/client.html");
   }
-  function startWebSocket(callback){
+
+  function startWebSocket(callback) {
     var self = this;
-    var cs = http.createServer(function(request, response) {
+    var cs = http.createServer(function (request, response) {
       var parsed = url.parse(request.url, true);
       if (parsed.query && parsed.query.cmd === "authStatus") {
-        setTimeout(function(){
+        setTimeout(function () {
           sendAuthStatusToApp(parsed.query.pzhid, parsed.query.authCode, parsed.query.connected);
         }, 3000);
       }
       handleRequest(parsed.pathname, request, response);
     });
 
-    cs.on("error", function(err) {
+    cs.on("error", function (err) {
       if (err.code === "EADDRINUSE") {
-        ports.pzp_web_webSocket = parseInt(ports.pzp_web_webSocket , 10) + 1;
-        cs.listen(ports.pzp_web_webSocket , address);
+        ports.pzp_web_webSocket = parseInt(ports.pzp_web_webSocket, 10) + 1;
+        cs.listen(ports.pzp_web_webSocket, address);
       } else {
         return callback(false, err);
       }
 
     });
 
-    cs.listen(ports.pzp_web_webSocket, address, function(){
-      logger.log("webSocket server listening on port "+ports.pzp_web_webSocket  + " and hostname "+address);
+    cs.listen(ports.pzp_web_webSocket, address, function () {
+      logger.log("webSocket server listening on port " + ports.pzp_web_webSocket + " and hostname " + address);
       return callback(true);
     });
   }
-  function startHttpServer(callback){
+
+  function startHttpServer(callback) {
     var self = this;
-    var httpserver = http.createServer(function(request, response) {
+    var httpserver = http.createServer(function (request, response) {
       logger.log("received request for " + request.url);
       response.writeHead(404);
       response.end();
     });
 
-    httpserver.on("error", function(err) {
+    httpserver.on("error", function (err) {
       if (err.code === "EADDRINUSE") {
-        ports.pzp_webSocket = parseInt(ports.pzp_webSocket, 10) +1;
+        ports.pzp_webSocket = parseInt(ports.pzp_webSocket, 10) + 1;
         logger.error("address in use, now trying port " + ports.pzp_webSocket);
         httpserver.listen(ports.pzp_webSocket, address);
       } else {
@@ -168,75 +163,105 @@ var PzpWSS = function() {
       }
     });
 
-	httpserver.on("listening",function() {
+    httpserver.on("listening", function () {
       logger.log("httpServer listening at port " + ports.pzp_webSocket + " and hostname " + address);
       return callback(true, httpserver);
-	});
-	
+    });
+
     httpserver.listen(ports.pzp_webSocket, address);
   }
+
   function startAndroidWRT() {
-    if(wrtServer) {
-      wrtServer.listener = function(connection) {
+    if (wrtServer) {
+      wrtServer.listener = function (connection) {
         logger.log("connection accepted and adding proxy connection methods.");
-        connection.socket = { pause: function(){}, resume: function(){} };
+        connection.socket = {
+          pause: function () {},
+          resume: function () {}
+        };
         connection.sendUTF = connection.send;
 
         connectedApp(connection);
 
         connection.listener = {
-          onMessage: function(ev)   { wsMessage(connection, ev.data); },
-          onClose: function()       { wsClose(connection); },
-          onError: function(reason) { logger.error(reason); }
+          onMessage: function (ev) {
+            wsMessage(connection, "android", ev.data);
+          },
+          onClose: function () {
+            wsClose(connection);
+          },
+          onError: function (reason) {
+            logger.error(reason);
+          }
         };
       };
     }
   }
+
   function connectedApp(connection) {
-    var appId, tmp, payload, connectedPzhIds = [],  connectedPzpIds= [], key, msg;
+    var appId, tmp, payload, connectedPzhIds = [],
+      connectedPzpIds = [],
+      key, msg;
     connectedPzpIds = self.getConnectedPzp();
     connectedPzhIds = self.getConnectedPzh();
     if (connection) {
-      appId = sessionId+ "/"+ sessionWebApp;
-      sessionWebApp  += 1;
+      appId = sessionId + "/" + sessionWebApp;
+      sessionWebApp += 1;
       connectedWebApp[appId] = connection;
       connection.id = appId; // this appId helps in while deleting socket connection has ended
 
-      payload = { "pzhId": pzhId, "connectedPzp": connectedPzpIds, "connectedPzh": connectedPzhIds};
+      payload = {
+        "pzhId": pzhId,
+        "connectedPzp": connectedPzpIds,
+        "connectedPzh": connectedPzhIds
+      };
       msg = prepMsg(sessionId, appId, "registeredBrowser", payload);
       self.sendConnectedApp(appId, msg);
     } else {
       for (key in connectedWebApp) {
         if (connectedWebApp.hasOwnProperty(key)) {
           tmp = connectedWebApp[key];
-          if (key.split("/").length > 2)
-            break;
-          key = sessionId+ "/" + key.split("/")[1];
+          if (key.split("/").length > 2) break;
+          key = sessionId + "/" + key.split("/")[1];
           tmp.id = key;
           connectedWebApp[key] = tmp;
-          payload = {"pzhId":sessionId.split("/")[0],"connectedPzp": connectedPzpIds,"connectedPzh": connectedPzhIds};
+          payload = {
+            "pzhId": sessionId.split("/")[0],
+            "connectedPzp": connectedPzpIds,
+            "connectedPzh": connectedPzhIds
+          };
           msg = prepMsg(sessionId, key, "registeredBrowser", payload);
           self.sendConnectedApp(key, msg);
         }
       }
     }
   }
-  function handleData(data){
+
+  function handleData(data) {
     var msg = JSON.parse(data);
-    if (msg.payload && msg.payload.status ==="signedCert") {
+    if (msg.payload && msg.payload.status === "signedCert") {
       self.enrolledPzp(msg.from, msg.to, msg.payload.message.clientCert, msg.payload.message.masterCert, msg.payload.message.masterCrl);
-    } else if (msg.payload && msg.payload.status === "authStatus"){
+    } else if (msg.payload && msg.payload.status === "authStatus") {
       sendAuthStatusToApp(msg.from, msg.payload.message.authCode, msg.payload.message.connected);
-    } else if (msg.payload && (msg.payload.status === "login" || msg.payload.status === "authenticate") && connectedWebApp[msg.to]){
+    } else if (msg.payload && (msg.payload.status === "login" || msg.payload.status === "authenticate") && connectedWebApp[msg.to]) {
       connectedWebApp[msg.to].sendUTF(JSON.stringify(msg));
     }
   }
-  function autoEnrollment(query) {
+
+  function autoEnrollment(query, origin) {
     var msg, sendAdd;
     var cmd = query.payload.status;
     var to = query.to;
     var from = query.from;
     var value = query.payload.message;
+
+    var originUrl = url.parse(origin);
+    if (originUrl.hostname !== "localhost" && originUrl.hostname !== "127.0.0.1") {
+
+      logger.error("Autoenrolment request from non-local origin: " + originUrl.hostname);
+      return;
+    }
+
 
     if (to && to.split('_')) {
       sendAdd = to.split('_')[0];
@@ -244,14 +269,20 @@ var PzpWSS = function() {
       sendAdd = to;
     }
 
-    if(cmd === "authStatus") {
+    if (cmd === "authStatus") {
       sendAuthStatusToApp(from, value.authCode, value.connected);
     } else if (cmd === "authenticate") {
-      msg = prepMsg(from, to, "authenticate", {"provider": value, "returnPath": "localhost:"+ ports.pzp_web_webSocket+"/client/client.html"});
+      msg = prepMsg(from, to, "authenticate", {
+        "provider": value,
+        "returnPath": "localhost:" + ports.pzp_web_webSocket + "/client/client.html"
+      });
     } else if (cmd === "login" || cmd === "registerPzh") {
-      msg = prepMsg(from, to, cmd );
+      msg = prepMsg(from, to, cmd);
     } else if (cmd === "enrollPzp") {
-      msg = prepMsg(sessionId, to, "enrollPzp", {"csr": csr, "authCode": value});
+      msg = prepMsg(sessionId, to, "enrollPzp", {
+        "csr": csr,
+        "authCode": value
+      });
     }
 
     var options = {
@@ -264,13 +295,13 @@ var PzpWSS = function() {
       }
     };
 
-    var req = https.request(options, function(res) {
-      res.on('data', function(data) {
+    var req = https.request(options, function (res) {
+      res.on('data', function (data) {
         handleData(data);
       });
     });
 
-    req.on('error', function(err) {
+    req.on('error', function (err) {
       logger.error(err);
     });
 
@@ -278,39 +309,59 @@ var PzpWSS = function() {
     req.end();
   }
 
- function sendAuthStatusToApp(to, value, status ) {
-    var appId, msg = prepMsg(sessionId, "", "authStatus", {connected: status, pzhId: to, authCode: decodeURIComponent(value)});
+  function sendAuthStatusToApp(to, value, status) {
+    var appId, msg = prepMsg(sessionId, "", "authStatus", {
+      connected: status,
+      pzhId: to,
+      authCode: decodeURIComponent(value)
+    });
     for (appId in connectedWebApp) {
-      if (connectedWebApp.hasOwnProperty(appId)){
+      if (connectedWebApp.hasOwnProperty(appId)) {
         msg.to = appId;
         connectedWebApp[appId].sendUTF(JSON.stringify(msg));
       }
     }
   }
-  this.startWebSocketServer = function(_pzhId, _sessionId, _address, _ports, _csr, callback) {
-    address   = _address;
-    pzhId     = _pzhId;
-    sessionId = _sessionId;
-    ports     = _ports;
-    csr       = _csr;
 
-    startWebSocket(function(status, value) {
+  function approveRequest(request) {
+    var requestor = request.host.split(":")[0]; // don't care about port.
+    return (requestor === "localhost" || requestor === "127.0.0.1");
+  }
+
+  this.startWebSocketServer = function (_pzhId, _sessionId, _address, _ports, _csr, callback) {
+    address = _address;
+    pzhId = _pzhId;
+    sessionId = _sessionId;
+    ports = _ports;
+    csr = _csr;
+
+    startWebSocket(function (status, value) {
       if (status) {
-        startHttpServer(function(status, value){
-          if(status){
-            if (wrtServer){
+        startHttpServer(function (status, value) {
+          if (status) {
+            if (wrtServer) {
               startAndroidWRT();
             }
             wsServer = new WebSocketServer({
               httpServer: value,
-              autoAcceptConnections: true
+              autoAcceptConnections: false
             });
 
-            wsServer.on("connect", function(connection) {
-              logger.log("connection accepted.");
-              connectedApp(connection);
-              connection.on("message", function(message) { wsMessage(connection, message.utf8Data); });
-              connection.on("close", function(reason, description) { wsClose(connection, description) });
+            wsServer.on("request", function (request) {
+              logger.log("Request for a websocket, origin: " + request.origin + ", host: " + request.host);
+              if (approveRequest(request)) {
+                var connection = request.accept();
+                logger.log("Request accepted");
+                connectedApp(connection);
+                connection.on("message", function (message) {
+                  wsMessage(connection, request.origin, message.utf8Data);
+                });
+                connection.on("close", function (reason, description) {
+                  wsClose(connection, description)
+                });
+              } else {
+                logger.error("Failed to accept websocket connection: " + "wrong host or origin");
+              }
             });
 
             return callback(true);
@@ -324,18 +375,18 @@ var PzpWSS = function() {
     });
   };
 
-  this.sendConnectedApp= function(address, message) {
-    if (connectedWebApp.hasOwnProperty(address)){
+  this.sendConnectedApp = function (address, message) {
+    if (connectedWebApp.hasOwnProperty(address)) {
       var jsonString = JSON.stringify(message);
-      logger.log('send to '+ address + ' message ' + jsonString );
+      logger.log('send to ' + address + ' message ' + jsonString);
       connectedWebApp[address].socket.pause();
       connectedWebApp[address].sendUTF(jsonString);
       connectedWebApp[address].socket.resume();
     } else {
-      logger.error("unknown destination " + address );
+      logger.error("unknown destination " + address);
     }
   };
-  this.updateApp = function(inputSessionId) {
+  this.updateApp = function (inputSessionId) {
     if (inputSessionId) {
       sessionId = inputSessionId;
     }


### PR DESCRIPTION
The PZP will now check for websocket connections to make sure:

(1) They come from localhost
(2) That if they attempt to do autoenrolment, their origin hostname
is 'localhost' or '127.0.0.1'.

This is a quick fix to WP-329 and fixes some indentation

Jira issue: WP-329
