### PR TITLE
Wp 250 multiple pzp on single host

### DIFF
--- a/webinos/core/manager/messaging/lib/messagehandler.js
+++ b/webinos/core/manager/messaging/lib/messagehandler.js
@@ -176,6 +176,9 @@
 	 *  @param to  Message destination
 	 */
 	MessageHandler.prototype.registerSender = function(from, to) {
+		logger.log('creating register msg to send from ' + from + ' to ' + to);
+		if (from === to) throw new Error('cannot create register msg to itself');
+
 		var options = {};
 		options.register = true;
 		options.to = to;

--- a/webinos/core/pzh/lib/pzh_provider.js
+++ b/webinos/core/pzh/lib/pzh_provider.js
@@ -121,7 +121,12 @@ var Provider = function(_hostname, _friendlyName) {
    */
   function loadSession (callback) {
     config  = new session.configuration();
-    config.setConfiguration(friendlyName, "PzhP", hostname, function (status, value) {
+    var inputConfig = {
+      "friendlyName": friendlyName,
+      "sessionIdentity": hostname
+    };
+
+    config.setConfiguration("PzhP", inputConfig, function (status, value) {
       if (!status) {
         logger.error("setting configuration for the zone provider failed, the .webinos directory needs to be deleted.")
         return callback(status, value);

--- a/webinos/core/pzh/lib/pzh_sessionHandling.js
+++ b/webinos/core/pzh/lib/pzh_sessionHandling.js
@@ -258,9 +258,12 @@ var Pzh = function () {
     auth_code.createAuthCounter(function (res) {
       self.pzh_state.expecting = res;
     });
-
+    var inputConfig = {
+      "friendlyName": _friendlyName,
+      "sessionIdentity": _uri
+    };
     self.config  = new session.configuration();
-    self.config.setConfiguration(_friendlyName, "Pzh", _uri, function (status, value) {
+    self.config.setConfiguration("Pzh", inputConfig, function (status, value) {
       if (status) {
         self.config.storeUserDetails(_user);
         self.pzh_state.sessionId = _uri;

--- a/webinos/core/pzp/lib/pzp_sessionHandling.js
+++ b/webinos/core/pzp/lib/pzp_sessionHandling.js
@@ -228,7 +228,7 @@ var Pzp = function () {
   this.initializePzp = function(inputConfig, modules, callback) {
     try {
     self.config = new Session.configuration();// sets configuration
-    self.config.setConfiguration(inputConfig.friendlyName, "Pzp", inputConfig.hostname, function (status) {
+    self.config.setConfiguration("Pzp", inputConfig, function (status) {
       if(status){
         checkMode();   //virgin or hub mode
         self.setSessionId();//sets pzp sessionId

--- a/webinos/core/util/lib/webinosId.js
+++ b/webinos/core/util/lib/webinosId.js
@@ -17,7 +17,20 @@
  * Copyright 2011 Ziran Sun, Samsung Electronics (UK) Ltd
  *******************************************************************************/
 var os = require('os');
-exports.fetchDeviceName = function(type, name, callback) {
+/**
+ * Determines the device name.
+ *
+ * @param type the type of PZ entity, string.
+ * @param config object with optional forcedDeviceName property, overrides device name.
+ * @param callback function which is called with device name as param.
+ */
+exports.fetchDeviceName = function(type, config, callback) {
+  // use user defined device name if given
+  if (config && config.forcedDeviceName) {
+    callback(config.forcedDeviceName + "_" + type);
+    return;
+  }
+
   //Get Android devices identity
   if(type === "Pzp" && (os.type().toLowerCase() === "linux") && (os.platform().toLowerCase() === "android")){
     var bridge = require("bridge");
@@ -33,19 +46,19 @@ exports.fetchDeviceName = function(type, name, callback) {
     };
 
     function onsuccess(prop_value, prop){
-      callback (prop_value + "_"+ type); //devicename_type
+      callback(prop_value + "_"+ type);
     }
 
     function onerror(){
       log.error("android get device name returns error");
-      callback ("android"+ "_"+ type);
+      callback("android"+ "_"+ type);
     }
 
     var devStatusModule = bridge.load('org.webinos.impl.DevicestatusImpl', this);
     devStatusModule.getPropertyValue(onsuccess, onerror, prop);
-  } else  if ((type === "Pzp" || type === "PzhP")){
-    callback (os.hostname() + "_"+ type); //devicename_type
-  } else {
-    callback( name);
+  } else if ((type === "Pzp" || type === "PzhP")){
+    callback(os.hostname() + "_"+ type);
+  } else if (type === "Pzh"){
+    callback(config.friendlyName);
   }
 };

--- a/webinos_pzp.js
+++ b/webinos_pzp.js
@@ -29,9 +29,7 @@ function help() {
   console.log("Options:");
   console.log("--pzh-host=[ipaddress]   host of the pzh (default localhost)");
   console.log("--pzh-name=[name]        name of the pzh (default \"\")");
-  console.log("--friendly-name=[name]   name of the pzp (default \"\")");
-  console.log("--auth-code=[code]       context debug flag (default DEBUG)");
-  console.log("--preference=[option]    preference option (default hub, other option peer)");
+  console.log("--friendly-name=[name]   friendly name (currently unused)");
   console.log("--widgetServer           start widget server");
   console.log("--policyEditor           start policy editor server");
   process.exit();
@@ -52,11 +50,8 @@ process.argv.forEach(function (arg) {
       case "--friendly-name":
         options.friendlyName = parts[1];
         break;
-      case "--preference":
-        options.preference = parts[1];
-        break;
-      case "--auth-code":
-        options.code = parts[1];
+      case "--force-device-name":
+        options.forcedDeviceName = parts[1];
         break;
       default:
         console.log("unknown option: " + parts[0]);
@@ -115,35 +110,20 @@ fs.readFile(path.join(__dirname, "config-pzp.json"), function(err, data) {
     if (!config.pzhName) {
       config.pzhName = "";
     }
-    if (!config.pzpHost) {
-      config.pzpHost="localhost";
-    }
     if (!config.friendlyName) {
       config.friendlyName = "";
-    }
-    if (!config.code) {
-      config.code = "DEBUG";
-    }
-    if (!config.preference) {
-      config.prefence = "hub";
     }
     if (options.pzhHost) {
       config.pzhHost = options.pzhHost;
     }
     if (options.pzhName) {
-  config.pzhName = options.pzhName;
-    }
-    if (options.pzpHost) {
-      config.pzpHost = options.pzpHost;
+      config.pzhName = options.pzhName;
     }
     if (options.friendlyName) {
       config.friendlyName = options.friendlyName;
     }
-    if (options.code) {
-      config.code = options.code;
-    }
-    if (options.preference) {
-      config.preference = options.preference;
+    if (options.forcedDeviceName) {
+      config.forcedDeviceName = options.forcedDeviceName;
     }
     if (config.pzhName !== "") {
       config.hostname = config.pzhHost+'/'+config.pzhName;


### PR DESCRIPTION
This fixes a few issues introduced with since the merge of the session changes in WP-250. It wasn't possible to run two PZPs on a single host. These two commits make that possible again, even though there is still work left to make it properly work again (see http://jira.webinos.org/browse/WP-467)

With these changes two PZPs can communicate with each other indirectly over the PZH.

Jira-issue: http://jira.webinos.org/browse/WP-250
