### PR TITLE
Use "window" instead of "this"

### DIFF
--- a/webinos/core/manager/messaging/lib/messagehandler.js
+++ b/webinos/core/manager/messaging/lib/messagehandler.js
@@ -432,7 +432,7 @@
 		exports.MessageHandler = MessageHandler;
 	} else {
 		// export for web browser
-		this.MessageHandler = MessageHandler;
+		window.MessageHandler = MessageHandler;
 	}
 
 }());

--- a/webinos/core/rpc/lib/registry.js
+++ b/webinos/core/rpc/lib/registry.js
@@ -181,6 +181,6 @@
 		var crypto = require('crypto');
 	} else {
 		// export for web browser
-		this.Registry = Registry;
+		window.Registry = Registry;
 	}
 })();

--- a/webinos/core/rpc/lib/rpc.js
+++ b/webinos/core/rpc/lib/rpc.js
@@ -22,14 +22,12 @@
 	if (typeof webinos === 'undefined')
 		webinos = {};
 	var logger = console;
-//    var policyManager = {'enforceRPCRequest':function(scope, jsonRPC, from, msgid){handleRequest.call(scope, jsonRPC, from, msgid)}};
 	if (typeof module === 'undefined') {
 		var exports = {};
 	} else {
 		var exports = module.exports = {};
 		var webinos_= require("find-dependencies")(__dirname);
 		logger  = webinos_.global.require(webinos_.global.util.location, "lib/logging.js")(__filename);
-//        policyManager = webinos_.global.require(webinos_.global.manager.policy_manager.location).policyManager;
 	}	
 
 	var idCount = 0;
@@ -312,7 +310,6 @@
 
 		if (typeof jsonRPC.method !== 'undefined' && jsonRPC.method != null) {
 			// received message is RPC request
-//            policyManager.enforceRPCRequest(this, jsonRPC, from, msgid, handleRequest);
 			handleRequest.call(this, jsonRPC, from, msgid);
 		} else {
 			// received message is RPC response
@@ -536,8 +533,8 @@
 
 	} else {
 		// export for web browser
-		this.RPCHandler = _RPCHandler;
-		this.RPCWebinosService = RPCWebinosService;
-		this.ServiceType = ServiceType;
+		window.RPCHandler = _RPCHandler;
+		window.RPCWebinosService = RPCWebinosService;
+		window.ServiceType = ServiceType;
 	}
 })();


### PR DESCRIPTION
In strict mode "this" inside a function doesn't become the window object.
Functions need to explicitely called with context. To avoid this, we use
the window object directly instead of "this". That's what non strict mode
does anyway.

Jira-issue: http://jira.webinos.org/browse/WP-564
