### PR TITLE
WP-506: updated js lib for Device Status API

### DIFF
--- a/webinos/core/api/devicestatus/lib/webinos.devicestatus.js
+++ b/webinos/core/api/devicestatus/lib/webinos.devicestatus.js
@@ -33,7 +33,7 @@
 	};
 
 	DeviceStatusManager.prototype.getPropertyValue = function (successCallback, errorCallback, prop) {
-        nativeDeviceStatus.getPropertyValue(prop.aspect, prop.property, prop.component);
+        	successCallback(nativeDeviceStatus.getPropertyValue(prop.aspect, prop.property, prop.component));
 	};
 
 	DeviceStatusManager.prototype.watchPropertyChange = function (successCallback, errorCallback, prop, options) {

--- a/webinos/core/api/devicestatus/lib/webinos.rpc.devicestatus.js
+++ b/webinos/core/api/devicestatus/lib/webinos.rpc.devicestatus.js
@@ -26,10 +26,6 @@
 	
 	RemoteDeviceStatusManager.prototype.isSupported = 
 		function (params, successCallback) {
-			console.log(params[0]);
-			console.log(params[1]);
-			console.log("successCallback is:" + successCallback);
-			
 			devicestatusmodule.devicestatus.isSupported(
 				params[0],
 				params[1],


### PR DESCRIPTION
Removed some console.log from device status rpc file
Fixed call to successCallback (method getPropertyValue) in the js lib
for Device Status API

Jira issue: WP-506
