### PR TITLE
Don't try to build webinos.js with ant

### DIFF
--- a/webinos/platform/android/build.xml
+++ b/webinos/platform/android/build.xml
@@ -53,8 +53,8 @@
 				**/.gitignore" />
 		</zip>
 
-                <!-- Creates webinos/web_root/webinos.js -->
-                <ant dir="${basedir}/webinos" target="gen-webinos-js" />
+                <!-- Creates webinos/web_root/webinos.js
+                <ant dir="${basedir}/webinos" target="gen-webinos-js" /> -->
 
                 <!-- Copies webinos/web_root/webinos.js to wrt/assets folder -->
                 <copy file="${basedir}/webinos/web_root/webinos.js" todir="${basedir}/webinos/platform/android/wrt/assets/js" />


### PR DESCRIPTION
Jira issue: WP-202

The building of webinos.js has been migrated to use grunt; therefore
this build.xml no longer attempts to create it.
