### PR TITLE
Removes the need of having grunt installed globally.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   , "mkdirp" : "0.3.x"
   , "connect" : "2.6.x"
   , "grunt-contrib-clean" : ">= 0.3.x"
+  , "grunt" : ">= 0.3.x"
   }
 , "engines" :
   { "node" : ">= 0.6.0"
@@ -42,6 +43,6 @@
   , "webinos_pzp": "webinos_pzp.js"
   }
 , "scripts":
-  { "install": "node-gyp configure build && cd webinos && grunt && cd .."
+  { "install": "node-gyp configure build && node_modules/grunt/bin/grunt"
   }
 }

--- a/webinos/core/manager/localconnection_manager/package.json
+++ b/webinos/core/manager/localconnection_manager/package.json
@@ -4,7 +4,7 @@
 , "keywords": [ "webinos", "Local", "Peer", "Discovery", "Connection", "Manager"]
 , "version": "0.0.1"
 , "homepage": "http://webinos.org/"
-, "author": "Ziran Sun <ziran.sun@samsung.com>
+, "author": "Ziran Sun <ziran.sun@samsung.com>"
 , "repository":
   { "type": "git"
   , "url": "https://github.com/webinos/Webinos-Platform.git"


### PR DESCRIPTION
Recently grunt was added to package.json to improve the generation of webinos.js.

However this adds the dependency to have grunt installed globally. For platform developers this is probably no problem as they might want to generate the webinos.js as part of their development process anyway.

For users and app developers this adds another step to the installation of the webinos platform.

Accepting this pull removes the need of having grunt installed globally. IMO this would be an improvement.

Jira issue: WP-202
