### PR TITLE
Add sqlite3 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   , "connect" : "2.6.x"
   , "grunt-contrib-clean" : "~0.3.x"
   }
+, "optionalDependencies" :
+  { "sqlite3" : "2.1.x"
+  }
 , "engines" :
   { "node" : ">= 0.6.0"
   , "npm" : ">= 1.1.17"


### PR DESCRIPTION
using version 2.1.x we can support node 0.6.13+ and 0.8.x
It was added on the optionalDependencies in order to allow the building process even if the device can't build sqlite3 module.

Jira issue: WP-397
