### PR TITLE
Wp 640 & 397 added optionalDependencies on package.json, added sqlite3 and moved qrcode

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   , "connect" : "2.6.x"
   , "grunt-contrib-clean" : "~0.3.x"
   }
+, "optionalDependencies" :
+  { "sqlite3" : "2.1.x"
+  }
 , "engines" :
   { "node" : ">= 0.6.0"
   , "npm" : ">= 1.1.17"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   , "crypt" : "0.0.x"
   , "ejs" : "0.x.x"
   , "openid" : "0.x.x"
-  , "qrcode" : "0.x.x"
   , "websocket" : "1.0.2"
   , "ansi" : "0.0.x"
   , "mdns" : "0.x.x"
@@ -36,6 +35,7 @@
   }
 , "optionalDependencies" :
   { "sqlite3" : "2.1.x"
+  , "qrcode" : "0.x.x"
   }
 , "engines" :
   { "node" : ">= 0.6.0"


### PR DESCRIPTION
Wp 640 & 397 added optionalDependencies on package.json, added sqlite3 and moved qrcode there too.

Add sqlite3 in package.json using version 2.1.x we can support node 0.6.13+ and 0.8.x
It was added on the optionalDependencies in order to allow the building process even if the device can't build sqlite3 module.

Jira issue: WP-397

Move qrcode node module to optionalDependencies …
qrcode has building issues on windows systems, pzp doesn't use it and it's not mandatory by the pzh to work so we can skip it if it fails.

The code that uses it, already handles the case that it doesn't exist.

Jira issue: WP-640
