### PR TITLE
Updated Android build script to include testbed

### DIFF
--- a/webinos/platform/android/build.xml
+++ b/webinos/platform/android/build.xml
@@ -38,7 +38,6 @@
 				webinos/core/wrt/,
 				
                 webinos/web_root/tests/,
-                webinos/web_root/testbed/,
 				webinos/web_root/api_test_specs/,
 				webinos/web_root/apps/,
 				webinos/web_root/*.html,


### PR DESCRIPTION
Removed testbed folder from excluded folders because we need this for the PZP web interface

Jira-issue: http://jira.webinos.org/browse/WP-30
