### PR TITLE
Use mdns version 1.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   , "openid" : "0.x.x"
   , "websocket" : "1.0.2"
   , "ansi" : "0.0.x"
-  , "mdns" : "0.x.x"
+  , "mdns" : "1.x.x"
   , "now" : "0.8.1"
   , "node-uuid" : "1.3.x"
   , "find-dependencies" : "~0.0.2"


### PR DESCRIPTION
A new version of mdns that works with Windows, Linux and Mac has been released to npm.

Jira issue: wp-646
