### PR TITLE
fix dig sig tests

### DIFF
--- a/node_modules/xmldigsig.js
+++ b/node_modules/xmldigsig.js
@@ -495,7 +495,7 @@ exports.Validator = (function() {
 			return;
 		}
 
-		if(reference.Transform != C14N_ALGORITHM_XML11) {
+		if(!(reference.Transform in C14N_ALGORITHMS) || !C14N_ALGORITHMS[reference.Transform]) {
 			this.emit('unsupported', new Error('validateSameDocumentReference: reference ' + reference.URI + ' has unsupported Transform'));
 			return;
 		}

--- a/webinos/core/manager/widget_manager/lib/digsig/signaturevalidator.js
+++ b/webinos/core/manager/widget_manager/lib/digsig/signaturevalidator.js
@@ -81,7 +81,7 @@ this.SignatureValidator = (function() {
 			 * If an author signature is present in the widget package, verify
 			 * that signature has a ds:Reference for the author signature.
 			 */
-			if(this.sigNum > 0 && 0 in this.widgetValidator.signatureNames)
+			if(this.signum > 0 && 0 in this.widgetValidator.signatureNames)
 				expectedRefs = ['author-signature.xml'].concat(expectedRefs);
 			
 			var dereferencer = function(ref, hash) {
@@ -180,7 +180,7 @@ this.SignatureValidator = (function() {
 
 			var signature = new Signature(this.name, signatureId, this.certificatePath);	
 			this.widgetValidator.addSignature(signature);
-			console.log(util.inspect(this));
+			//console.log(util.inspect(this));
 		} catch(e) {
 			this.widgetValidator.setInvalid(new Error('Internal error: exception = ' + e));
 		}


### PR DESCRIPTION
The digital signature tests 24a, 29a, and 33a are failing to pass. This PR fixes some bugs to allow 24a and 29a to pass, but 33a will not be fixed.

See http://jira.webinos.org/browse/WP-582
