### PR TITLE
PZP state handling changes

### DIFF
--- a/webinos/core/pzp/lib/pzp_otherManager.js
+++ b/webinos/core/pzp/lib/pzp_otherManager.js
@@ -44,7 +44,7 @@ var Pzp_OtherManager = function (_parent) {
    * Any entity connecting to PZP has to register its address with other end point
    */
   function registerMessaging(pzhId) {
-    if (_parent.pzp_state.connectedPzh[pzhId] && _parent.pzp_state.mode === _parent.modes[1]) {
+    if (_parent.pzp_state.connectedPzh[pzhId] && _parent.pzp_state.enrolled) {
       var msg = self.messageHandler.registerSender(_parent.pzp_state.sessionId, pzhId);
       _parent.sendMessage(msg, pzhId);
     }
@@ -128,7 +128,7 @@ var Pzp_OtherManager = function (_parent) {
    */
   this.registerServicesWithPzh = function() {
     var pzhId = _parent.config.metaData.pzhId;
-    if (_parent.pzp_state.connectedPzh[pzhId] && _parent.pzp_state.mode === _parent.modes[1]) {
+    if (_parent.pzp_state.connectedPzh[pzhId] && _parent.pzp_state.enrolled) {
       var localServices = self.discovery.getRegisteredServices();
       var msg = {"type" : "prop", "from" : _parent.pzp_state.sessionId, "to": pzhId, "payload":{"status":"registerServices",
         "message":{services:localServices, from: _parent.pzp_state.sessionId}}};

--- a/webinos/core/pzp/lib/pzp_websocket.js
+++ b/webinos/core/pzp/lib/pzp_websocket.js
@@ -260,7 +260,11 @@ var PzpWSS = function(_parent) {
       connectedWebApp[appId] = connection;
       connection.id = appId; // this appId helps in while deleting socket connection has ended
 
-      payload = { "pzhId": parent.config.metaData.pzhId, "connectedPzp": getConnectedPzp(), "connectedPzh": getConnectedPzh()};
+      payload = { "pzhId":parent.config.metaData.pzhId,
+        "connectedPzp" :getConnectedPzp (),
+        "connectedPzh" :getConnectedPzh (),
+        "state"        :parent.pzp_state.state,
+        "enrolled"     :parent.pzp_state.enrolled};
       msg = prepMsg(parent.pzp_state.sessionId, appId, "registeredBrowser", payload);
       self.sendConnectedApp(appId, msg);
 
@@ -281,7 +285,11 @@ var PzpWSS = function(_parent) {
           key = parent.pzp_state.sessionId+ "/" + key.split("/")[1];
           tmp.id = key;
           connectedWebApp[key] = tmp;*/
-          payload = {"pzhId": parent.config.metaData.pzhId, "connectedPzp":  getConnectedPzp(),"connectedPzh":  getConnectedPzh()};
+          payload = { "pzhId":parent.config.metaData.pzhId,
+            "connectedPzp" :getConnectedPzp (),
+            "connectedPzh" :getConnectedPzh (),
+            "state"        :parent.pzp_state.state,
+            "enrolled"     :parent.pzp_state.enrolled};
           msg = prepMsg(parent.pzp_state.sessionId, key, "update", payload);
           self.sendConnectedApp(key, msg);
         }

--- a/webinos/core/wrt/lib/webinos.session.js
+++ b/webinos/core/wrt/lib/webinos.session.js
@@ -18,7 +18,7 @@
 (function() {
   "use strict";
   webinos.session = {};
-  var sessionId = null, pzpId, pzhId, otherPzp = [], otherPzh = [], isConnected = false;
+  var sessionId = null, pzpId, pzhId, otherPzp = [], otherPzh = [], isConnected = false, enrolled = false, mode;
   var serviceLocation;
   var listenerMap = {};
   var channel;
@@ -43,7 +43,12 @@
     if(typeof to === "undefined") {
       to = pzpId;
     }
-    var message = {"type":type, "id":id, "from":webinos.session.getSessionId(), "to":to, "resp_to":webinos.session.getSessionId(), "payload":rpc};
+    var message = {"type":type,
+      "id":id,
+      "from":webinos.session.getSessionId(),
+      "to":to,
+      "resp_to":webinos.session.getSessionId(),
+      "payload":rpc};
     if(rpc.register !== "undefined" && rpc.register === true) {
       console.log(rpc);
       channel.send(JSON.stringify(rpc));
@@ -79,6 +84,13 @@
   webinos.session.getOtherPZH = function() {
     return (otherPzh || []);
   };
+  webinos.session.getPzpModeState = function (mode_name) {
+    if (enrolled && mode[mode_name] === "connected") {
+      return true;
+    } else {
+      return false;
+    }
+  };
   webinos.session.addListener = function(statusType, listener) {
     var listeners = listenerMap[statusType] || [];
     listeners.push(listener);
@@ -106,13 +118,12 @@
     var msg = webinos.messageHandler.registerSender(sessionId, pzpId);
     webinos.session.message_send(msg, pzpId);
   }
-  function setIsConnected() {
-    isConnected = (otherPzh.indexOf(pzhId) !== -1) ? true: false;
-  }
   function updateConnected(message){
     otherPzh = message.connectedPzh;
     otherPzp = message.connectedPzp;
-    setIsConnected();
+    isConnected = (otherPzh.indexOf (pzhId) !== -1) ? true : false;
+    enrolled = message.enrolled;
+    mode = message.mode;
   }
   function setWebinosSession(data){
     sessionId = data.to;


### PR DESCRIPTION
Introduced getPzpModeStatus on the client side to find if PZP is in peer or hub mode. On the server side state and mode variable has been preceded by state which keeps track of mode states.

Jira Issue: WP-656
