### PR TITLE
Fixed sensor/iot register service defects + fix of command signatures

### DIFF
--- a/webinos/core/api/actuator/lib/actuator_iot.js
+++ b/webinos/core/api/actuator/lib/actuator_iot.js
@@ -101,13 +101,21 @@
             successCB(tmp);
         };
         
+        var CmdErrorHandler = function(rpcErrorCB) {
+            this.rpcErrorCB = rpcErrorCB;      
+            this.errorCB = function(message) {
+                rpcErrorCB(message);
+            };
+        };
         this.setValue = function(value, successCB, errorCB) {
-            driverInterface.sendCommand('value', this.elementId, value);
-            //TODO wait a callback from driver before sending the callback?
+            driverInterface.sendCommand('value', this.elementId,
+                    value, new CmdErrorHandler(errorCB).errorCB);
             actuatorEvent.actualValue = value;
             actuatorEvent.actuatorId = this.id;
+            // If driver haven't called the error callback before returning
+            // from it is assumed that everything went ok.
             successCB(actuatorEvent);
-        }
+        };
     }
 
 

--- a/webinos/core/api/actuator/lib/rpc_actuator.js
+++ b/webinos/core/api/actuator/lib/rpc_actuator.js
@@ -40,7 +40,6 @@ var RPCWebinosService = require('webinos-jsonrpc2').RPCWebinosService;
         if (impl == 'iot') {
             dilib = require(__dirname+'/../../iotdrivers/lib/driverInterface.js');
             actlib = require(__dirname+'/actuator_iot.js');
-            driverInterface = new dilib.driverInterface(1, driverListener);
         }
         else if (impl == 'old') {
             actlib = require(__dirname+'/actuator_old.js');
@@ -51,7 +50,11 @@ var RPCWebinosService = require('webinos-jsonrpc2').RPCWebinosService;
             console.log('Init old actuator service');
             regFunc = register;
             unregFunc = unregister;
-            if (impl == 'old') {
+            if (impl == 'iot') {
+                driverInterface = new dilib.driverInterface();
+                driverInterface.connect(1, driverListener);
+            }
+            else if (impl == 'old') {
                 var service = new actlib.ActuatorService(rpcHandler);
                 regFunc(service);
             }

--- a/webinos/core/api/iotdrivers/lib/driverInterface.js
+++ b/webinos/core/api/iotdrivers/lib/driverInterface.js
@@ -23,7 +23,7 @@
 
     var fs = require('fs');
 
-    var initialized = false;
+    var driversLoaded = false;
 
     var driversLocation = __dirname+'/drivers/';
     var driversList = new Array;
@@ -42,26 +42,13 @@
      * @param sensorActuator identifies if this is instantiated by the actuator or sensor api
      * @param listener listener of the sensor/actuator api to be called when needed
      */
-    var driverInterface = function(sensorActuator, listener) {
-        console.log('Driver Interface constructor - sa is '+sensorActuator);
-        if(!initialized) {
+    var driverInterface = function() {
+        console.log('Driver Interface constructor');
+        if(!driversLoaded) {
             loadDrivers();
-            initialized = true;
+            driversLoaded = true;
         }
-
-        // The listener function (implmeted in the api) has the signature:
-        // listener(DOMString cmd, int id, DOMString data) where
-        // cmd is the command (register, data, ...)
-        // id is the is of the element(it's assigned at registration time)
-        // data are data (their value depend on the command)
-        apiListener[sensorActuator] = listener;
-
-
-        this.sendCommand = function(cmd, elementId, data) {
-            driversList[elementList[elementId].driverId].execute(cmd, elementId, data);
-        }
-
-
+        
         function loadDrivers() {
             console.log('loadDrivers');
             var fileList = fs.readdirSync(driversLocation);
@@ -69,7 +56,6 @@
                 console.log('File found: '+fileList[i]+' - id is '+newDriverId);
                 try {
                     var newDriver = require(driversLocation+fileList[i]);
-                    newDriver.init(newDriverId, register, command);
                     driversList[newDriverId++] = newDriver;
                 }
                 catch(e) {
@@ -77,6 +63,48 @@
                 }
             }
             console.log('loadDrivers: '+driversList.length+' drivers successfully loaded');
+        }
+        
+        this.connect = function (sensorActuator, listener) {
+            console.log('connect sa is '+sensorActuator);
+            // The listener function (implmeted in the api) has the signature:
+            // listener(DOMString cmd, int id, DOMString data) where
+            // cmd is the command (register, data, ...)
+            // id is the is of the element(it's assigned at registration time)
+            // data are data (their value depend on the command)
+            apiListener[sensorActuator] = listener;
+            
+            // Since each driver can host sensors or actuators or even both
+            // we have to make sure that listeners for both sensors and actuators 
+            // is set up (module loaded) before we start initializing and receive 
+            // callbacks from drivers.
+            var allListenersLoaded = true;
+            for (var i = 0; i < 2; i++) {
+                if (apiListener[i] == 'undefined' || apiListener[i] == null) {
+                    allListenersLoaded = false;
+                    break;
+                }
+            }
+            if (allListenersLoaded) {
+                initDrivers();
+            }
+        }
+        
+        function initDrivers() {
+            console.log('initDrivers');
+            for(var i in driversList) {
+                try {
+                    driversList[i].init(i, register, command);
+                }
+                catch(e) {
+                    console.log('Error: cannot initialize driver '+ driversList[i]);
+                }
+            }
+        }
+ 
+
+        this.sendCommand = function(cmd, elementId, data, errorCB) {
+            driversList[elementList[elementId].driverId].execute(cmd, elementId, data, errorCB);
         }
 
 

--- a/webinos/core/api/iotdrivers/lib/drivers/fakeDriver1.js
+++ b/webinos/core/api/iotdrivers/lib/drivers/fakeDriver1.js
@@ -92,8 +92,6 @@
                 break;
             case 'start':
                 //In this case the sensor should start data acquisition
-                //the parameter data has value 'fixed' (in case of fixed interval
-                // acquisition) or 'change' (in case od acquisition on value change)
                 console.log('Received start for element '+eId+', mode is '+data);
                 var index = -1;
                 for(var i in elementsList) {

--- a/webinos/core/api/iotdrivers/lib/drivers/httpDriver.js
+++ b/webinos/core/api/iotdrivers/lib/drivers/httpDriver.js
@@ -108,7 +108,7 @@ var port;
                 //the parameter data has value 'fixed' (in case of fixed interval
                 // acquisition) or 'change' (in case od acquisition on value change)
                 console.log('Received start command from API. Element : '+eId+', mode : '+data);
-                var mode = (data === "fixed") ? FIXEDINTERVAL_MODE : VALUECHANGE_MODE;                
+                var mode = FIXEDINTERVAL_MODE;                
                 makeHTTPRequest(boards[board_id].ip, boards[board_id].port, START_LISTENING_CMD, native_element_id, mode);
                 break;
             case 'stop':

--- a/webinos/core/api/sensors/lib/rpc_sensors.js
+++ b/webinos/core/api/sensors/lib/rpc_sensors.js
@@ -40,7 +40,6 @@ var RPCWebinosService = require('webinos-jsonrpc2').RPCWebinosService;
         if (impl == 'iot') {
             dilib = require(__dirname+'/../../iotdrivers/lib/driverInterface.js');
             sslib = require(__dirname+'/sensor_iot.js');
-            driverInterface = new dilib.driverInterface(0, driverListener);
         }
         else if (impl == 'fake') {
             sslib = require(__dirname+'/sensor_fake.js');
@@ -50,7 +49,11 @@ var RPCWebinosService = require('webinos-jsonrpc2').RPCWebinosService;
         this.init = function(register, unregister) {
             regFunc = register;
             unregFunc = unregister;
-            if (impl == 'fake') {
+            if (impl == 'iot') {
+                driverInterface = new dilib.driverInterface();
+                driverInterface.connect(0, driverListener);
+            }
+            else if (impl == 'fake') {
                 var service = new sslib.SensorService(rpcHandler);
                 regFunc(service);
             }

--- a/webinos/core/api/sensors/lib/sensor_iot.js
+++ b/webinos/core/api/sensors/lib/sensor_iot.js
@@ -139,29 +139,38 @@ var RPCWebinosService = require("webinos-jsonrpc2").RPCWebinosService;
             return sensorEvent;
         }
         
+        var CmdErrorHandler = function(rpcErrorCB) {
+            this.rpcErrorCB = rpcErrorCB;      
+            this.errorCB = function(message) {
+                rpcErrorCB(message);
+            };
+        };
+        
         /**
         * Configures a sensor.
         * @param params
         * @param successCB
         * @param errorCB
         */
-        this.configureSensor = function (params, successHandler, errorHandler){
+        this.configureSensor = function(params, successCB, errorCB) {
             console.log("Configuring sensor with params : "+JSON.stringify(params));
-            driverInterface.sendCommand('cfg', this.elementId, params);
-            successHandler(); //TODO probably successCB should be passed to sendCommand and called by driver
+            driverInterface.sendCommand('cfg', this.elementId, params,
+                    new CmdErrorHandler(errorCB).errorCB);
         };
         
-        this.addEventListener = function (eventType, successHandler, errorHandler, objectRef) {
+        this.addEventListener = function (eventType, successCB, errorCB, objectRef) {
             console.log('Sensor '+sensorEvent.sensorId+': addEventListener');
             this.objRef = objectRef;
             this.listenerActive = true;
-            driverInterface.sendCommand('start', this.elementId, 'fixed');
-        }
+            driverInterface.sendCommand('start', this.elementId, null,
+                    new CmdErrorHandler(errorCB).errorCB);
+        };
 
-        this.removeEventListener = function (eventType, successHandler, errorHandler, objectRef) {
+        this.removeEventListener = function (eventType, successCB, errorCB, objectRef) {
             this.listenerActive = false;
-            driverInterface.sendCommand('stop', this.elementId, null);
-        }
+            driverInterface.sendCommand('stop', this.elementId, null,
+                    new CmdErrorHandler(errorCB).errorCB);
+        };
     }
 
     SensorService.prototype = new RPCWebinosService;


### PR DESCRIPTION
Jira-issue: WP-712

There was some defects in iot driver design which meant that if
a driver tried to register directly in the init function this
would fail. The following had to be done:
- Loading and initializing drivers is done in 2 separate steps since
  a driver can contain both sensor and/or actuators and both listeners
  has to be initialized.
- Driverinterface is created and then as a separate function call
  the module is connected. otherwise the sensor/actuator module haven't
  stored the driverinterface reference when registrations are called
  back.

Also, some changes has been made to some of the driverinterface
command signatures to better support the needed use-cases:
- An error callback has been added to driverinterface commands
  so that drivers can report errors back.
- The hard-coded eventmode parameter sent in 'start' command data
  has been removed. In accordance with the Sensor API this is sent
  in configuration data instead.
