### PR TITLE
Add appstate sync api

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -57,6 +57,7 @@ module.exports = function(grunt) {
           'webinos/core/wrt/lib/webinos.sensors.js',
           'webinos/core/wrt/lib/webinos.events.js',
           'webinos/core/wrt/lib/webinos.app2app.js',
+          'webinos/core/wrt/lib/webinos.appstatesync.js',
           'webinos/core/wrt/lib/webinos.applauncher.js',
           'webinos/core/wrt/lib/webinos.vehicle.js',
           'webinos/core/wrt/lib/webinos.deviceorientation.js',

--- a/webinos/core/wrt/lib/webinos.appstatesync.js
+++ b/webinos/core/wrt/lib/webinos.appstatesync.js
@@ -1,0 +1,265 @@
+/*******************************************************************************
+ *  Code contributed to the webinos project
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * Copyright 2011 Alexander Futasz, Fraunhofer FOKUS
+ ******************************************************************************/
+(function() {
+	var _sync = new SyncManager({
+		"api": "http://webinsdf/sync",
+		"name": "sync",
+		"id": "foo"
+	});
+
+	webinos.__defineGetter__('sync', function() {
+		return _sync;
+	});
+
+	/**
+	 * @constructor
+	 * @param obj Object containing displayName, api, etc.
+	 */
+	function SyncManager(obj) {
+		this.base = WebinosService;
+		this.base(obj);
+
+		var _app2app;
+		var _chanMap = {};
+		var _watchMap = {};
+
+		var that = this;
+		var _callerCache = [];
+		var finishCallers = function() {
+			for (var i = 0; i < _callerCache.length; i++) {
+				var caller = _callerCache[i];
+				webinos.sync[caller.func].apply(that, caller.params);
+			}
+			_callerCache = [];
+		};
+
+		webinos.discovery.findServices({"api": "http://webinos.org/api/app2app"}, {
+			onFound: function (unboundService) {
+				_app2app = unboundService; // FIXME should be assigned on bind
+				unboundService.bindService({onBind: function(sv) {
+					finishCallers();
+				}});
+			}
+		});
+
+		this.create = function (id, successCallback, errorCallback, options) {
+			if (!_app2app) {
+				_callerCache.push({
+					"func": "create",
+					"params": [id, successCallback, errorCallback, options]
+				});
+				return;
+			}
+
+			var messageCallback = function (msg) {
+				console.log("got appstate sync msg");
+				var scb = _watchMap[msg.contents[0]+msg.contents[1]];
+				if (scb) {
+					scb({
+						"propertyPath": msg.contents[1],
+						"previousValue": msg.contents[3],
+						"currentValue": msg.contents[2]
+					});
+				}
+			};
+
+			var creatSyOb = function(c, connect, searchOp) {
+				if (searchOp) searchOp.cancel();
+
+				var chan = _chanMap[id];
+				if (chan) chan.ref++;
+				
+				_chanMap[id] = chan ? chan : {"chan": c, "ref": 0};
+				var so = options && options.referenceObject ?
+						new SyncObject(id, options.referenceObject) : new SyncObject(id);
+
+				if (connect) {
+					c.connect({"source": id}, messageCallback, function() {
+						successCallback(so);
+					}, function(err) {
+						errorCallback(err);
+					});
+				} else {
+					successCallback(so);
+				}
+			};
+			
+			var search = function() {
+				var op = _app2app.searchForChannels("urn:syncobj:" + id, [], function searchCallback(chan) {
+					console.log("Found existing channel for sync obj");
+					creatSyOb(chan, true, op);
+				}, function succCallbackSearch() {
+					
+				}, function errCallbackSearch(err) {
+					if (err.message === "There is already a search in progress.") {
+						setTimeout(function() {
+							search();
+						}, 600);
+					} else {
+						if (errorCallback) errorCallback(err);
+					}
+				});
+			};
+
+			_app2app.createChannel({
+				"namespace": "urn:syncobj:" + id,
+				"properties": { "mode": "send-receive" },
+				"appInfo": {}
+			}, function requestCallback(req) {
+				return true;
+			},
+			messageCallback, 
+			function succCallbackCreate(chan) {
+				creatSyOb(chan);
+			}, function errCallbackCreate(err) {
+				if (err.message === "Channel already exists.") {
+					search();
+				} else {
+					if (errorCallback) errorCallback(err);
+				}
+			});
+		};
+
+		/**
+		 */
+		this.find = function (id, successCallback, errorCallback) {
+			if (!_app2app) {
+				_callerCache.push({
+					"func": "find",
+					"params": [id, successCallback, errorCallback]
+				});
+				return;
+			}
+
+		};
+
+		/**
+		 */
+		this.detach = function (id, successCallback, errorCallback) {
+			if (!_app2app) {
+				_callerCache.push({
+					"func": "detach",
+					"params": [id, successCallback, errorCallback]
+				});
+				return;
+			}
+
+		};
+
+		/**
+		 */
+		this.remove = function (id, successCallback, errorCallback) {
+			if (!_app2app) {
+				_callerCache.push({
+					"func": "remove",
+					"params": [id, successCallback, errorCallback]
+				});
+				return;
+			}
+
+			var chan = _chanMap[id];
+			if (!chan) {
+				if (errorCallback) errorCallback({"message": "couldn't remove, already removed?"});
+				return;
+			}
+			chan.chan.disconnect(function() {
+				successCallback();
+			});
+			chan.ref--;
+			if (chan.ref === 0) {
+				delete _chanMap[id];
+			}
+			successCallback();
+		};
+
+		function SyncObject(id, data) {
+			var _id = id;
+			var _data;
+			this.data = {};
+
+			var clone = function(obj) {
+				if (obj == null || typeof(obj) != 'object')
+					return obj;
+
+				var temp = new obj.constructor();
+				for (var key in obj)
+					temp[key] = clone(obj[key]);
+
+				return temp;
+			};
+			_data = clone(data);
+
+			var get = function(prop) {
+				return _data[prop];
+			};
+			var set = function(prop, val) {
+				var chan = _chanMap[id];
+				chan.chan.send([id, prop, val, _data[prop]]);
+				_data[prop] = val;
+			};
+			var defineProp = function(prop) {
+				Object.defineProperty(this.data, prop, {
+					configurable: true,
+					enumeable: true,
+					writeable: true,
+					get: function() {
+						return get.call(this, prop);
+					},
+					set: function(val) {
+						set.call(this, prop, val);
+					}
+				});
+			};
+
+			// use props from data as template for this object
+			for (var prop in _data) {
+				if (!prop) break;
+
+				defineProp.call(this, prop);
+			}
+
+			var that = this;
+			this.watch = function(prop, successCallback, errorCallback) {
+				var chan = _chanMap[id];
+				if (!chan) {
+					errorCallback({message: 'not connected'});
+					return;
+				}
+				_watchMap[id+prop] = successCallback;
+
+				if (that.data[prop]) {
+					_data[prop] = that.data[prop];
+					delete that.data[prop];
+				}
+				defineProp.call(that, prop);
+			};
+
+			this.unwatch = function(prop, successCallback, errorCallback) {
+				var chan = _chanMap[id];
+				if (!chan) {
+					errorCallback({message: 'not connected'});
+					return;
+				}
+			};
+		}
+
+	};
+
+	SyncManager.prototype = new WebinosService;
+
+}());

--- a/webinos/web_root/tests/api_tests/appstatesync/2ndsyncapp.html
+++ b/webinos/web_root/tests/api_tests/appstatesync/2ndsyncapp.html
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+  "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+  <title>2nd app</title>
+
+  <!-- include source files here... -->
+  <script type="text/javascript" src="../../../webinos.js"></script>
+
+  <script type="text/javascript" src="2ndsyncapp.js"></script>
+
+</head>
+
+<body>
+</body>
+</html>

--- a/webinos/web_root/tests/api_tests/appstatesync/2ndsyncapp.js
+++ b/webinos/web_root/tests/api_tests/appstatesync/2ndsyncapp.js
@@ -1,0 +1,17 @@
+
+var objTemplate = {
+	"prop0": "nop"
+};
+
+webinos.sync.create("_testObjIdOtherApp", function(syncObj) {
+	console.log("created test sync object in other app");
+
+	syncObj.data.prop0 = "baz";
+	
+	console.log("set prop on sync object in other app");
+
+}, function(err) {
+	console.log(err);
+}, { // options
+	referenceObject: objTemplate
+});

--- a/webinos/web_root/tests/api_tests/appstatesync/AppStateSyncSpec.js
+++ b/webinos/web_root/tests/api_tests/appstatesync/AppStateSyncSpec.js
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ *  Code contributed to the webinos project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2011 Alexander Futasz, Fraunhofer FOKUS
+ ******************************************************************************/
+
+function add$(success) {
+	var done = false;
+	var script = document.createElement("script");
+	script.src = "//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js";
+	script.onload = script.onreadystatechange = function() {
+		if (!done && (!this.readyState
+				|| this.readyState == 'loaded'
+					|| this.readyState == 'complete') ) {
+			done = true;
+			success();
+			script.onload = script.onreadystatechange = null;
+		}
+	};
+	document.head.appendChild(script);
+};
+
+beforeEach(function() {
+	this.addMatchers({
+		toHaveProp: function(expected) {
+			return typeof this.actual[expected] !== "undefined";
+		}
+	});
+});
+
+describe("AppState Sync API", function() {
+	var testSyncObj;
+
+	var PROPVAL = "foo";
+	var PROPVALOTHERAPP = "baz";
+	var objTemplate = {
+		"prop0": PROPVAL
+	};
+
+	it("is there", function() {
+		expect(webinos.sync).toBeDefined();
+	});
+
+	it("has all the functions", function() {
+		expect(webinos.sync.create).toBeDefined();
+		expect(webinos.sync.find).toBeDefined();
+		expect(webinos.sync.detach).toBeDefined();
+		expect(webinos.sync.remove).toBeDefined();
+	});
+
+	it("creates a sync object", function() {
+		webinos.sync.create("_testObjId", function(syncObj) {
+			expect(syncObj).toEqual(jasmine.any(Object));
+			expect(syncObj.watch).toEqual(jasmine.any(Function));
+			expect(syncObj.unwatch).toEqual(jasmine.any(Function));
+			expect(syncObj.data).toEqual(jasmine.any(Object));
+			expect(syncObj.data.prop0).toEqual(PROPVAL);
+			testSyncObj = syncObj;
+		}, function(err) {
+			console.log(err);
+		}, { // options
+			referenceObject: objTemplate
+		});
+
+		waitsFor(function() {
+			return !!testSyncObj;
+		}, "success callback called");
+	});
+	
+	it("removes a sync object", function() {
+		var removed;
+		webinos.sync.remove("_testObjId", function() {
+			removed = true;
+		});
+
+		waitsFor(function() {
+			return removed;
+		}, "success callback called");
+	});
+
+	it("can sync object between apps", function() {
+		var testSyncObjOtherApp;
+		var watched;
+		var appended;
+		var removed;
+
+		webinos.sync.create("_testObjIdOtherApp", function(syncObj) {
+			expect(syncObj).toEqual(jasmine.any(Object));
+			expect(syncObj.watch).toEqual(jasmine.any(Function));
+			expect(syncObj.unwatch).toEqual(jasmine.any(Function));
+			expect(syncObj.data).toEqual(jasmine.any(Object));
+			expect(syncObj.data.prop0).toEqual(PROPVAL);
+			testSyncObjOtherApp = syncObj;
+		}, function(err) {
+			console.log(err);
+		}, { // options
+			referenceObject: objTemplate
+		});
+
+		waitsFor(function() {
+			return !!testSyncObjOtherApp;
+		}, "success callback called");
+		
+		runs(function() {
+			testSyncObjOtherApp.watch("prop0", function(o) {
+				expect(o).toEqual(jasmine.any(Object));
+				expect(o.propertyPath).toEqual("prop0");
+				expect(o.currentValue).toEqual(PROPVALOTHERAPP);
+				watched = true;
+			});
+		});
+
+		runs(function() {
+			add$(function() {
+				$('<iframe />', {
+					name: "2ndsyncapp",
+					src: "2ndsyncapp.html"
+				}).appendTo("body");
+				appended = true;
+				$("iframe").hide();
+			});
+		});
+
+		waitsFor(function() {
+			return appended;
+		});
+
+		waitsFor(function() {
+			return watched;
+		}, "prop watch callback being called");
+
+		runs(function() {
+			webinos.sync.remove("_testObjIdOtherApp", function() {
+				removed = true;
+			});
+		});
+
+		waitsFor(function() {
+			return removed;
+		}, "success callback called");
+	});
+});

--- a/webinos/web_root/tests/api_tests/appstatesync/SpecRunner.html
+++ b/webinos/web_root/tests/api_tests/appstatesync/SpecRunner.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+  "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+  <title>Jasmine Spec Runner</title>
+
+  <link rel="stylesheet" type="text/css" href="../../test_frameworks/jasmine-1.2.0/jasmine.css">
+  <script type="text/javascript" src="../../test_frameworks/jasmine-1.2.0/jasmine.js"></script>
+  <script type="text/javascript" src="../../test_frameworks/jasmine-1.2.0/jasmine-html.js"></script>
+  <script type="text/javascript" src="../../test_frameworks/jasmine-execute.js"></script>
+
+  <!-- include source files here... -->
+  <script type="text/javascript" src="../../../webinos.js"></script>
+
+  <!-- include spec files here... -->
+  <script type="text/javascript" src="AppStateSyncSpec.js"></script>
+
+</head>
+
+<body>
+</body>
+</html>


### PR DESCRIPTION
This implementation is based on the app2app api, it is only client-side running
in the browser or wrt.

In order for the api to recognize when there are properties to sync it needs to
know about those properties. Either a template object with existing
properties is used when creating the sync object or for a new prop added later
to a sync obj it is needed to call watch on for them first, so they can be
synced.

Also needs https://github.com/webinos/Webinos-Platform/pull/440.

Jira-issue: http://jira.webinos.org/browse/WP-235
