### PR TITLE
Improve jasmine api tests

### DIFF
--- a/webinos/web_root/tests/api_tests/JasmineSpecRunner.html
+++ b/webinos/web_root/tests/api_tests/JasmineSpecRunner.html
@@ -14,15 +14,17 @@
 
   <!-- include spec files here... -->
 
-  <script type="text/javascript" src="events/EventsSpec.js"></script>
-  <script type="text/javascript" src="discovery/DiscoverySpec.js"></script>
-  <script type="text/javascript" src="geolocation/GeolocationSpec.js"></script>
-  <script type="text/javascript" src="gallery/gallerySpec.js"></script>
-  <script type="text/javascript" src="applauncher/applauncherSpec.js"></script>  
-  <script type="text/javascript" src="payment/PaymentSpec.js"></script>
-  <script type="text/javascript" src="vehicle/vehicleSpec.js"></script>
-  <script type="text/javascript" src="tv/TVControlSpec.js"></script>
+  <script type="text/javascript" src="app2app/App2AppSpec.js"></script>
+  <script type="text/javascript" src="applauncher/applauncherSpec.js"></script>
+  <script type="text/javascript" src="contacts/ContactsSpec.js"></script>
   <script type="text/javascript" src="devicestatus/DeviceStatusSpec.js"></script>
+  <script type="text/javascript" src="discovery/DiscoverySpec.js"></script>
+  <script type="text/javascript" src="events/EventsSpec.js"></script>
+  <script type="text/javascript" src="gallery/gallerySpec.js"></script>
+  <script type="text/javascript" src="geolocation/GeolocationSpec.js"></script>
+  <script type="text/javascript" src="payment/PaymentSpec.js"></script>
+  <script type="text/javascript" src="tv/TVControlSpec.js"></script>
+  <script type="text/javascript" src="vehicle/vehicleSpec.js"></script>
 </head>
 
 <body>

--- a/webinos/web_root/tests/api_tests/app2app/App2AppSpec.js
+++ b/webinos/web_root/tests/api_tests/app2app/App2AppSpec.js
@@ -2,14 +2,6 @@ describe("app2app messaging api", function () {
   var TIMEOUT = 1000;
   var app2appService;
 
-  function addMatchers() {
-    this.addMatchers({
-      toHaveProp:function (expected) {
-        return typeof this.actual[expected] !== "undefined"
-      }
-    })
-  }
-
   function findService() {
     runs(function () {
       webinos.discovery.findServices(
@@ -22,7 +14,7 @@ describe("app2app messaging api", function () {
 
     waitsFor(function () {
       return !!app2appService
-    }, "the service to be discovered", TIMEOUT)
+    }, "the service to be discovered")
   }
 
   function bindService() {
@@ -88,19 +80,18 @@ describe("app2app messaging api", function () {
   });
 
   describe("contract", function () {
-    beforeEach(addMatchers);
     beforeEach(findService);
     beforeEach(bindService);
     afterEach(clearService);
 
     it("has the necessary generic service methods and properties", function () {
-      expect(app2appService).toHaveProp("state");
+      expect(app2appService.state).toBeDefined();
       expect(app2appService.api).toEqual(jasmine.any(String));
       expect(app2appService.id).toEqual(jasmine.any(String));
       expect(app2appService.displayName).toEqual(jasmine.any(String));
       expect(app2appService.description).toEqual(jasmine.any(String));
       expect(app2appService.icon).toEqual(jasmine.any(String));
-      expect(app2appService.bindService).toEqual(jasmine.any(Function))
+      expect(app2appService.bindService).toEqual(jasmine.any(Function));
     });
 
     it("has the necessary api methods and properties", function () {
@@ -110,7 +101,6 @@ describe("app2app messaging api", function () {
   });
 
   describe("basic channel usage", function () {
-    beforeEach(addMatchers);
     beforeEach(findService);
     beforeEach(bindService);
     afterEach(clearService);
@@ -148,10 +138,10 @@ describe("app2app messaging api", function () {
 
 
       runs(function () {
-        expect(createdChannel).toHaveProp("client");
-        expect(createdChannel).toHaveProp("namespace");
-        expect(createdChannel).toHaveProp("properties");
-        expect(createdChannel).toHaveProp("appInfo");
+        expect(createdChannel.client).toBeDefined();
+        expect(createdChannel.namespace).toBeDefined();
+        expect(createdChannel.properties).toBeDefined();
+        expect(createdChannel.appInfo).toBeDefined();
         expect(createdChannel.connect).toEqual(jasmine.any(Function));
         expect(createdChannel.send).toEqual(jasmine.any(Function));
         expect(createdChannel.disconnect).toEqual(jasmine.any(Function));
@@ -182,10 +172,10 @@ describe("app2app messaging api", function () {
       });
 
       runs(function () {
-        expect(foundChannel).toHaveProp("client");
-        expect(foundChannel).toHaveProp("namespace");
-        expect(foundChannel).toHaveProp("properties");
-        expect(foundChannel).toHaveProp("appInfo");
+        expect(foundChannel.client).toBeDefined();
+        expect(foundChannel.namespace).toBeDefined();
+        expect(foundChannel.properties).toBeDefined();
+        expect(foundChannel.appInfo).toBeDefined();
         expect(foundChannel.connect).toEqual(jasmine.any(Function));
         expect(foundChannel.send).toEqual(jasmine.any(Function));
         expect(foundChannel.disconnect).toEqual(jasmine.any(Function))
@@ -225,7 +215,6 @@ describe("app2app messaging api", function () {
   })
 
   describe("channel search", function () {
-    beforeEach(addMatchers);
     beforeEach(findService);
     beforeEach(bindService);
     afterEach(clearService);
@@ -308,7 +297,6 @@ describe("app2app messaging api", function () {
   })
 
   describe("sending to single client", function () {
-    beforeEach(addMatchers);
     beforeEach(findService);
     beforeEach(bindService);
     afterEach(clearService);

--- a/webinos/web_root/tests/api_tests/applauncher/ApplauncherSpec.js
+++ b/webinos/web_root/tests/api_tests/applauncher/ApplauncherSpec.js
@@ -1,22 +1,16 @@
 describe('Applauncher API', function() {
 	var applauncherService;
 
+	webinos.discovery.findServices(new ServiceType("http://webinos.org/api/applauncher"), {
+		onFound: function (service) {
+			applauncherService = service;
+		}
+	});
+
 	beforeEach(function() {
-		this.addMatchers({
-			toHaveProp: function(expected) {
-				return typeof this.actual[expected] !== "undefined";
-			}
-		});
-
-		webinos.discovery.findServices(new ServiceType("http://webinos.org/api/applauncher"), {
-			onFound: function (service) {
-				applauncherService = service;
-			}
-		});
-
 		waitsFor(function() {
 			return !!applauncherService;
-		}, "The discovery didn't find an Applauncher service", 5000);
+		}, "finding Applauncher service", 5000);
 	});
 
 	it("should be available from the discovery", function() {
@@ -24,18 +18,12 @@ describe('Applauncher API', function() {
 	});
 
 	it("has the necessary properties as service object", function() {
-		expect(applauncherService).toHaveProp("state");
-		expect(applauncherService).toHaveProp("api");
+		expect(applauncherService.state).toBeDefined();
 		expect(applauncherService.api).toEqual(jasmine.any(String));
-		expect(applauncherService).toHaveProp("id");
 		expect(applauncherService.id).toEqual(jasmine.any(String));
-		expect(applauncherService).toHaveProp("displayName");
 		expect(applauncherService.displayName).toEqual(jasmine.any(String));
-		expect(applauncherService).toHaveProp("description");
 		expect(applauncherService.description).toEqual(jasmine.any(String));
-		expect(applauncherService).toHaveProp("icon");
 		expect(applauncherService.icon).toEqual(jasmine.any(String));
-		expect(applauncherService).toHaveProp("bindService");
 		expect(applauncherService.bindService).toEqual(jasmine.any(Function));
 	});
 
@@ -57,9 +45,9 @@ describe('Applauncher API', function() {
 	});
 
 	it("has the necessary properties and functions as Applauncher API service", function() {
-		expect(applauncherService).toHaveProp("launchApplication");
+		expect(applauncherService.launchApplication).toBeDefined();
 		expect(applauncherService.launchApplication).toEqual(jasmine.any(Function));
-		expect(applauncherService).toHaveProp("appInstalled");
+		expect(applauncherService.appInstalled).toBeDefined();
 		expect(applauncherService.appInstalled).toEqual(jasmine.any(Function));
 	});
 

--- a/webinos/web_root/tests/api_tests/contacts/ContactsSpec.js
+++ b/webinos/web_root/tests/api_tests/contacts/ContactsSpec.js
@@ -1,0 +1,381 @@
+/*******************************************************************************
+ *  Code contributed to the webinos project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2011
+ ******************************************************************************/
+
+describe("Contacts API", function() {
+	var contactsService;
+	var contactList;
+
+	// compares objects helper method
+	// call like this: equals.call(obj1, obj2)
+	var equals = function(x) {
+		var p;
+		for(p in this)
+			if(typeof(x[p])=='undefined') return false;
+		for(p in this) {
+			if (this[p])
+				switch(typeof(this[p])) {
+				case 'object':
+					if (!equals.call(this[p], x[p])) return false; 
+					break;
+				case 'function':
+					if (typeof(x[p])=='undefined' || (p != 'equals' && this[p].toString() != x[p].toString()))
+						return false;
+					break;
+				default:
+					if (this[p] != x[p]) return false; 
+				}
+			else
+				if (x[p]) return false;
+		}
+		for(p in x)
+			if(typeof(this[p])=='undefined') return false;
+		return true;
+	};
+
+	webinos.discovery.findServices(new ServiceType("http://www.w3.org/ns/api-perms/contacts"), {
+		onFound: function (service) {
+			contactsService = service;
+		}
+	});
+
+	beforeEach(function() {
+		waitsFor(function() {
+			return !!contactsService;
+		}, "finding a contacts service", 5000);
+	});
+
+	it("should be available from the discovery", function() {
+		expect(contactsService).toBeDefined();
+	});
+
+	it("has the necessary properties as service object", function() {
+		expect(contactsService.state).toBeDefined();
+		expect(contactsService.api).toEqual(jasmine.any(String));
+		expect(contactsService.id).toEqual(jasmine.any(String));
+		expect(contactsService.displayName).toEqual(jasmine.any(String));
+		expect(contactsService.description).toEqual(jasmine.any(String));
+		expect(contactsService.icon).toEqual(jasmine.any(String));
+		expect(contactsService.bindService).toEqual(jasmine.any(Function));
+	});
+
+	it("can be bound", function() {
+		var bound = false;
+
+		contactsService.bindService({onBind: function(service) {
+			contactsService = service;
+			bound = true;
+		}});
+
+		waitsFor(function() {
+			return bound;
+		}, "service to be bound", 500);
+
+		runs(function() {
+			expect(bound).toEqual(true);
+		});
+	});
+
+	describe("remote contacts tests", function() {
+		var param;
+
+		beforeEach(function() {
+			param = {};
+			param.usr = "";
+			param.pwd = "";
+			param.type = "remote";	
+		});
+
+		it("is not yet authenticated", function() {
+			var finished = false;
+			var authResult;
+
+			contactsService.isAlreadyAuthenticated(param, function(result) {
+				finished = true;
+				authResult = result;
+			});
+
+			waitsFor(function() {
+				return finished;
+			}, "isAlreadyAuthenticated callback.", 200);
+
+			runs(function() {
+				expect(authResult).toEqual(false);
+			});
+		});
+
+		it("is not authenticated as policy was denied", function() {
+			var finished = false;
+			var authResult;
+
+			contactsService.authenticate(param, function(result) {
+				finished = true;
+				authResult = result;
+			});
+			alert("Deny Policy Manager, before confirming this message.");
+
+			waitsFor(function() {
+				return finished;
+			}, "authenticated callback.", 7000);
+
+			runs(function() {
+				expect(authResult).toEqual(false);
+			});
+		});
+
+		it("is successfully authenticated", function() {
+			var finished = false;
+			var authResult;
+			param.usr = prompt("Please, enter a valid Google userID", "");
+			param.pwd = prompt("Please, enter your password", "");
+
+			contactsService.authenticate(param, function(result) {
+				finished = true;
+				authResult = result;
+			});
+			alert("Allow Policy Manager, before confirming this message.");
+
+			waitsFor(function() {
+				return finished;
+			}, "authenticated callback.", 7000);
+
+			runs(function() {
+				expect(authResult).toEqual(true);
+			});
+		});
+
+		it("can get all contacts", function() {
+			var finished = false;
+			param.fields = {};
+
+			contactsService.getAllContacts(param, function(contacts){
+				finished = true;
+				contactList = contacts;
+			});
+
+			waitsFor(function() {
+				return finished;
+			}, "getAllContacts callback.", 3000);
+
+			runs(function() {
+				expect(contactList.length).toBeGreaterThan(0);
+			});
+		});
+
+		it("can find contact based on filter", function() {
+			var finished = false;
+			var overQuota;
+			var filtered;
+			param.fields = {};
+			param.fields["displayName"] = contactList[0].displayName;
+			//TODO risolvere problema nella contact, se si filtra per un oggetto, come nel caso di param.name, vengono restituiti tutto i contatti che possiedono un nome, qualunque esso sia...
+
+			contactsService.find(param, function(contacts) {
+				//If Google responds in the photos field this: "Temporary problem - please try again later and consider using batch operations. The user is over quota." (base64 coded!!)
+				var serviceDenied = 'VGVtcG9yYXJ5IHByb2JsZW0gLSBwbGVhc2UgdHJ5IGFnYWluIGxhdGVyIGFuZCBjb25zaWRlciB1c2luZyBiYXRjaCBvcGVyYXRpb25zLiBUaGUgdXNlciBpcyBvdmVyIHF1b3RhLg=='; 
+
+				if (contacts.length > 0) {
+
+					if(contacts[0]['photos'][0].value === serviceDenied || contactList[0]['photos'][0].value === serviceDenied){
+						overQuota = true;
+						finished = true;
+						return;
+					}
+
+					var foundEqual = true;
+
+					for (var i in contacts[0]){
+						if(!equals.call(contacts[0][i], contactList[0][i]) && i != 'photos'){ //TODO: response from Google is not deterministic because base64 coding has padding
+							foundEqual = false;
+						}
+					}
+					filtered = foundEqual;
+				}
+
+				finished = true;
+			});
+
+			waitsFor(function() {
+				return finished;
+			}, "find contact with filter callback.", 3000);
+
+			runs(function() {
+				expect(overQuota).not.toEqual(true);
+				if (overQuota) {
+					// skip other expects if over quota
+					return;
+				}
+
+				expect(filtered).toEqual(true);
+			});
+		});
+
+		xit("cannot find contact based on filter for non-existing contact", function() {
+			var finished = false;
+			var contactsArray;
+			param.fields = {};
+			param.fields["displayName"] = "Ago"; // non-existing contact
+
+			contactsService.find(param, function(contacts) {
+				contactsArray = contacts;
+				finished = true;
+			});
+
+			waitsFor(function() {
+				return finished;
+			}, "find contact with filter callback.", 3000);
+
+			runs(function() {
+				expect(contactsArray.length).toEqual(0);
+			});
+		});
+	});
+
+	describe("local contacts tests", function() {
+		var param;
+
+		beforeEach(function() {
+			param = {};
+			param.usr = "";
+			param.pwd = "";
+			param.type = "local";
+			param.addressBookName = ""; // TODO path to .mab file
+		});
+
+		it("authenticate will fail if no valid mab file path", function() {
+			var finished;
+			var authenticated;
+			param.addressBookName = "";
+
+			contactsService.authenticate(param, function(result) {
+				authenticated = result;
+				finished = true;
+			});
+
+			waitsFor(function() {
+				return finished;
+			}, "authenticated callback.", 5000);
+
+			runs(function() {
+				expect(authenticated).toEqual(false);
+			});
+		});
+
+		it("is still not authenticated", function() {
+			var finished;
+			var authenticated;
+
+			contactsService.isAlreadyAuthenticated(param, function(result) {
+				authenticated = result;
+				finished = true;
+			});
+
+			waitsFor(function() {
+				return finished;
+			}, "isAlreadyAuthenticated callback.", 5000);
+
+			runs(function() {
+				expect(authenticated).toEqual(false);
+			});
+		});
+
+		it("authenticate successfully", function() {
+			var finished;
+			var authenticated;
+
+			contactsService.authenticate(param, function(result) {
+				authenticated = result;
+				finished = true;
+			});
+
+			waitsFor(function() {
+				return finished;
+			}, "authenticated callback.", 5000);
+
+			runs(function() {
+				expect(authenticated).toEqual(true);
+				finished = false;
+
+				contactsService.isAlreadyAuthenticated(param, function(result) {
+					authenticated = result;
+					finished = true;
+				});
+
+				waitsFor(function() {
+					return finished;
+				}, "isAlreadyAuthenticated callback.", 500);
+
+				runs(function() {
+					expect(authenticated).toEqual(true);
+				});
+			});
+		});
+
+		it("can get all contacts", function() {
+			var finished = false;
+
+			contactsService.getAllContacts(param, function(contacts){
+				finished = true;
+				contactList = contacts;
+			});
+
+			waitsFor(function() {
+				return finished;
+			}, "getAllContacts callback.", 1000);
+
+			runs(function() {
+				expect(contactList.length).toEqual(3);
+			});
+		});
+
+		it("all contacts have the proper fields", function() {
+			var finished = false;
+
+			contactsService.getAllContacts(param, function(contacts){
+				finished = true;
+				contactList = contacts;
+			});
+
+			waitsFor(function() {
+				return finished;
+			}, "getAllContacts callback.", 1000);
+
+			runs(function() {
+				for (var i = 0; i < contactList.length; i++) {
+					expect(contactList[i].id).toBeDefined();
+					expect(contactList[i].displayName).toBeDefined(); 
+					expect(contactList[i].name).toBeDefined();
+					expect(contactList[i].nickname).toBeDefined(); 
+					expect(contactList[i].phoneNumbers).toBeDefined();
+					expect(contactList[i].emails).toBeDefined();
+					expect(contactList[i].ims).toBeDefined();
+					expect(contactList[i].birthday).toBeDefined();
+					expect(contactList[i].organizations).toBeDefined(); 
+					expect(contactList[i].revision).toBeDefined();
+					expect(contactList[i].note).toBeDefined();
+					expect(contactList[i].photos).toBeDefined(); 
+					expect(contactList[i].urls).toBeDefined(); 
+					expect(contactList[i].addresses).toBeDefined(); 
+//					expect(contactList[i].gender).toBeDefined(); 
+//					expect(contactList[i].categories).toBeDefined();
+//					expect(contactList[i].timezone).toBeDefined();
+				}
+			});
+		});
+
+	});
+});

--- a/webinos/web_root/tests/api_tests/contacts/SpecRunner.html
+++ b/webinos/web_root/tests/api_tests/contacts/SpecRunner.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+  "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+  <title>Jasmine Spec Runner</title>
+
+  <link rel="stylesheet" type="text/css" href="../../test_frameworks/jasmine-1.2.0/jasmine.css">
+  <script type="text/javascript" src="../../test_frameworks/jasmine-1.2.0/jasmine.js"></script>
+  <script type="text/javascript" src="../../test_frameworks/jasmine-1.2.0/jasmine-html.js"></script>
+  <script type="text/javascript" src="../../test_frameworks/jasmine-execute.js"></script>
+
+  <!-- include source files here... -->
+  <script type="text/javascript" src="../../../webinos.js"></script>
+
+  <!-- include spec files here... -->
+  <script type="text/javascript" src="ContactsSpec.js"></script>
+
+</head>
+
+<body>
+</body>
+</html>

--- a/webinos/web_root/tests/api_tests/deviceorientation/deviceorientation.js
+++ b/webinos/web_root/tests/api_tests/deviceorientation/deviceorientation.js
@@ -21,34 +21,20 @@ var testService;
 
 // Specs tests
 describe('deviceorientation follows specs', function(){
-	beforeEach(function() {
-		this.addMatchers({
-			toBeFunction: function() {
-				return typeof this.actual === 'function';
-			},
-			toBeObject: function() {
-				return typeof this.actual === 'object';
-			},
-			toBeString: function() {
-				return typeof this.actual === 'string';
-			},
-			toBeNumber: function() {
-				return typeof this.actual === 'number';
-			}
-		});
-		webinos.discovery.findServices(new ServiceType("http://webinos.org/api/deviceorientation"), {
-			onFound: function (service) {
+	webinos.discovery.findServices(new ServiceType("http://webinos.org/api/deviceorientation"), {
+		onFound: function (service) {
 			testService = service;
-		}});
-		
+		}
+	});
+
+	beforeEach(function() {
 		waitsFor(function() {
 			return !!testService;
 		}, "The discovery didn't find an Device Orientation API", 5000);
-		
 	});
 	
 	it('has funtion bindService', function() {
-		expect(testService.bindService).toBeFunction();
+		expect(testService.bindService).toEqual(jasmine.any(Function));
 	});
 	
 	it("can be bound", function() {
@@ -69,11 +55,11 @@ describe('deviceorientation follows specs', function(){
 	});
 	
 	it('has funtion addEventListener', function() {
-		expect(testService.addEventListener).toBeFunction();
+		expect(testService.addEventListener).toEqual(jasmine.any(Function));
 	});
 	
 	it('has funtion removeEventListener', function() {
-		expect(testService.removeEventListener).toBeFunction();
+		expect(testService.removeEventListener).toEqual(jasmine.any(Function));
 	});
 	
 	it('api equals to "http://webinos.org/api/deviceorientation"', function() {
@@ -81,11 +67,11 @@ describe('deviceorientation follows specs', function(){
 	});
 	
 	it('displayName is string', function() {
-		expect(testService.displayName).toBeString();
+		expect(testService.displayName).toEqual(jasmine.any(String));
 	});
 	
 	it('description is string', function() {
-		expect(testService.description).toBeString();
+		expect(testService.description).toEqual(jasmine.any(String));
 	});
 		
 });

--- a/webinos/web_root/tests/api_tests/devicestatus/DeviceStatusSpec.js
+++ b/webinos/web_root/tests/api_tests/devicestatus/DeviceStatusSpec.js
@@ -18,19 +18,13 @@
 describe("DeviceStatus API", function() {
 	var devicestatusService;
 
+	webinos.discovery.findServices(new ServiceType("http://wacapps.net/api/devicestatus"), {
+		onFound: function (service) {
+			devicestatusService = service;
+		}
+	});
+
 	beforeEach(function() {
-		this.addMatchers({
-			toHaveProp: function(expected) {
-				return typeof this.actual[expected] !== "undefined";
-			}
-		});
-
-		webinos.discovery.findServices(new ServiceType("http://wacapps.net/api/devicestatus"), {
-			onFound: function (service) {
-				devicestatusService = service;
-			}
-		});
-
 		waitsFor(function() {
 			return !!devicestatusService;
 		}, "The discovery didn't find a DeviceStatus service", 5000);
@@ -41,7 +35,7 @@ describe("DeviceStatus API", function() {
 	});
 
 	it("has the necessary properties as service object", function() {
-		expect(devicestatusService).toHaveProp("state");
+		expect(devicestatusService.state).toBeDefined();
 		expect(devicestatusService.api).toEqual(jasmine.any(String));
 		expect(devicestatusService.id).toEqual(jasmine.any(String));
 		expect(devicestatusService.displayName).toEqual(jasmine.any(String));

--- a/webinos/web_root/tests/api_tests/events/EventsSpec.js
+++ b/webinos/web_root/tests/api_tests/events/EventsSpec.js
@@ -19,28 +19,18 @@
 describe("Events API", function() {
 	var eventsService;
 
-	beforeEach(function() {
-		this.addMatchers({
-			toHaveProp: function(expected) {
-				return typeof this.actual[expected] !== "undefined";
-			}
-		});
-
-		webinos.discovery.findServices(new ServiceType("http://webinos.org/api/events"), {
-			onFound: function (unboundService) {
-				unboundService.bindService({onBind: function(service) {
-					eventsService = service;
-				}});
-			}
-		});
-
-		waitsFor(function() {
-			return !!eventsService;
-		}, "Could not find or bind Events service", 5000);
+	webinos.discovery.findServices(new ServiceType("http://webinos.org/api/events"), {
+		onFound: function (unboundService) {
+			unboundService.bindService({onBind: function(service) {
+				eventsService = service;
+			}});
+		}
 	});
 
-	afterEach(function() {
-		eventsService = undefined;
+	beforeEach(function() {
+		waitsFor(function() {
+			return !!eventsService;
+		}, "finding Events service", 5000);
 	});
 
 	it("could be found and be bound", function() {
@@ -48,7 +38,7 @@ describe("Events API", function() {
 	});
 
 	it("has the necessary properties as service object", function() {
-		expect(eventsService).toHaveProp("state");
+		expect(eventsService.state).toBeDefined();
 		expect(eventsService.api).toEqual(jasmine.any(String));
 		expect(eventsService.id).toEqual(jasmine.any(String));
 		expect(eventsService.displayName).toEqual(jasmine.any(String));
@@ -65,10 +55,10 @@ describe("Events API", function() {
 
 	it("can create an event", function() {
 		var ev = eventsService.createWebinosEvent("testtype", {to: [{id: "to"}], source: {id: "from"}});
-		expect(ev).toHaveProp("type");
-		expect(ev).toHaveProp("addressing");
-		expect(ev).toHaveProp("id");
-		expect(ev).toHaveProp("timeStamp");
+		expect(ev.type).toBeDefined();
+		expect(ev.addressing).toBeDefined();
+		expect(ev.id).toBeDefined();
+		expect(ev.timeStamp).toBeDefined();
 		expect(ev.dispatchWebinosEvent).toEqual(jasmine.any(Function));
 		expect(ev.forwardWebinosEvent).toEqual(jasmine.any(Function));
 	});

--- a/webinos/web_root/tests/api_tests/geolocation/GeolocationSpec.js
+++ b/webinos/web_root/tests/api_tests/geolocation/GeolocationSpec.js
@@ -25,14 +25,6 @@ function checkPosition(position) {
 	expect(coords.accuracy).toEqual(jasmine.any(Number));
 }
 
-beforeEach(function() {
-	this.addMatchers({
-		toHaveProp: function(expected) {
-			return typeof this.actual[expected] !== "undefined";
-		}
-	});
-});
-
 describe("Geolocation API", function() {
 	var geolocationService;
 
@@ -53,7 +45,7 @@ describe("Geolocation API", function() {
 	});
 
 	it("has the necessary properties as service object", function() {
-		expect(geolocationService).toHaveProp("state");
+		expect(geolocationService.state).toBeDefined();
 		expect(geolocationService.api).toEqual(jasmine.any(String));
 		expect(geolocationService.id).toEqual(jasmine.any(String));
 		expect(geolocationService.displayName).toEqual(jasmine.any(String));

--- a/webinos/web_root/tests/api_tests/payment/PaymentSpec.js
+++ b/webinos/web_root/tests/api_tests/payment/PaymentSpec.js
@@ -19,19 +19,13 @@
 describe("Payment API", function() {
         var paymentService;
 
+        webinos.discovery.findServices(new ServiceType("http://webinos.org/api/payment"), {
+                onFound: function (service) {
+                    paymentService = service;
+                }
+        });
+
         beforeEach(function() {
-                this.addMatchers({
-                        toHaveProp: function(expected) {
-                                return typeof this.actual[expected] !== "undefined";
-                        }
-                });
-
-                webinos.discovery.findServices(new ServiceType("http://webinos.org/api/payment"), {
-                        onFound: function (service) {
-                                paymentService = service;                                
-                        }
-                });
-
                 waitsFor(function() {
                         return !!paymentService;
                 }, "The discovery didn't find a Payment service", 5000);
@@ -42,7 +36,7 @@ describe("Payment API", function() {
         });
 
         it("has the necessary properties as service object", function() {
-                expect(paymentService).toHaveProp("state");
+                expect(paymentService.state).toBeDefined();
                 expect(paymentService.api).toEqual(jasmine.any(String));
                 expect(paymentService.id).toEqual(jasmine.any(String));
                 expect(paymentService.displayName).toEqual(jasmine.any(String));
@@ -161,20 +155,20 @@ describe("Payment API", function() {
                 expect(myBasket.update).toEqual(jasmine.any(Function));
                 expect(myBasket.checkout).toEqual(jasmine.any(Function));
                 expect(myBasket.release).toEqual(jasmine.any(Function));
-                expect(myBasket).toHaveProp("items");
-                expect(myBasket).toHaveProp("extras");
-                expect(myBasket).toHaveProp("totalBill");
+                expect(myBasket.items).toBeDefined();
+                expect(myBasket.extras).toBeDefined();
+                expect(myBasket.totalBill).toBeDefined();
        });
        
 
         it("has the necessary properties and functions for a shopping item", function() {     
                       myItem=new ShoppingItem();
-                      expect(myItem).toHaveProp("productID");
-                      expect(myItem).toHaveProp("description");
-                      expect(myItem).toHaveProp("currency");
-                      expect(myItem).toHaveProp("itemPrice");
-                      expect(myItem).toHaveProp("itemCount");
-                      expect(myItem).toHaveProp("itemsPrice");
+                      expect(myItem.productID).toBeDefined();
+                      expect(myItem.description).toBeDefined();
+                      expect(myItem.currency).toBeDefined();
+                      expect(myItem.itemPrice).toBeDefined();
+                      expect(myItem.itemCount).toBeDefined();
+                      expect(myItem.itemsPrice).toBeDefined();
        });
          
         it("can add an item to a shopping basket",  function() {

--- a/webinos/web_root/tests/api_tests/tv/TVControlSpec.js
+++ b/webinos/web_root/tests/api_tests/tv/TVControlSpec.js
@@ -19,40 +19,39 @@
 //Test suite for tv module API according to spec at http://dev.webinos.org/specifications/draft/tv.html
 //Potential changes/diffs especially regarding the phase two of the project are marked as such.
 
+beforeEach(function() {
+	this.addMatchers({
+		toBeEither: function() {
+			for (var j=0;j<arguments.length;j++){
+				if (arguments[j]===this.actual)	return true;
+			}
+			return false;
+		},
+		toBePrintableString: function(){
+			return !(/[\x00-\x08\x0E-\x1F]/.test(this.actual)) && 
+				 typeof this.actual === "string" && this.actual.length>0;
+		},
+		toBeValidAsSourceForVideoElement: function(){
+			return typeof this.actual === "string" || 
+			(typeof this.actual !== "undefined" && 
+			 typeof this.actual.audioTracks !== "undefined" && 
+			 typeof this.actual.ended !== "undefined" && 
+			 typeof this.actual.label !== "undefined" &&
+			 typeof this.actual.videoTracks !== "undefined"  )
+		}
+	});
+});
+
 describe("tv module API", function() {
 	var tvService;
 
+	webinos.discovery.findServices(new ServiceType("http://webinos.org/api/tv"), {
+		onFound: function (service) {
+			tvService = service;
+		}
+	});
+
 	beforeEach(function() {
-		this.addMatchers({
-			toHaveProp: function(expected) {
-				return typeof this.actual[expected] !== "undefined";
-			},
-			toBeEither: function() {
-				for (var j=0;j<arguments.length;j++){
-					if (arguments[j]===this.actual)	return true;
-				}
-				return false;
-			},
-			toBePrintableString: function(){
-				return !(/[\x00-\x08\x0E-\x1F]/.test(this.actual)) && 
-					 typeof this.actual === "string" && this.actual.length>0;
-			},
-			toBeValidAsSourceForVideoElement: function(){
-				return typeof this.actual === "string" || 
-				(typeof this.actual !== "undefined" && 
-				 typeof this.actual.audioTracks !== "undefined" && 
-				 typeof this.actual.ended !== "undefined" && 
-				 typeof this.actual.label !== "undefined" &&
-				 typeof this.actual.videoTracks !== "undefined"  )
-			}
-		});
-
-		webinos.discovery.findServices(new ServiceType("http://webinos.org/api/tv"), {
-			onFound: function (service) {
-				tvService = service;
-			}
-		});
-
 		waitsFor(function() {
 			return !!tvService;
 		}, "the discovery to find an TV Control service", 10000);
@@ -63,7 +62,7 @@ describe("tv module API", function() {
 	});
 
 	it("has the necessary properties as service object", function() {
-		expect(tvService).toHaveProp("state");
+		expect(tvService.state).toBeDefined();
 		expect(tvService.api).toEqual(jasmine.any(String));
 		expect(tvService.id).toEqual(jasmine.any(String));
 		expect(tvService.displayName).toEqual(jasmine.any(String));

--- a/webinos/web_root/tests/api_tests/vehicle/vehicleSpec.js
+++ b/webinos/web_root/tests/api_tests/vehicle/vehicleSpec.js
@@ -20,22 +20,16 @@ describe("Vehicle API", function() {
 	var vehicleService;
 	var boundVehicleService;
 	
+	webinos.discovery.findServices(new ServiceType("http://webinos.org/api/vehicle"), {
+		onFound: function (service) {
+			vehicleService = service;
+			vehicleService.bindService({onBind: function(service) {
+				boundVehicleService = service;
+			}});
+		}
+	});
+
 	beforeEach(function() {
-		this.addMatchers({
-			toHaveProp: function(expected) {
-				return typeof this.actual[expected] !== "undefined";
-			}
-		});
-
-		webinos.discovery.findServices(new ServiceType("http://webinos.org/api/vehicle"), {
-			onFound: function (service) {
-				vehicleService = service;
-				vehicleService.bindService({onBind: function(service) {
-					boundVehicleService = service;
-				}});
-			}
-		});
-
 		waitsFor(function() {
 			return !!vehicleService;
 		}, "The discovery didn't find a Vehicle service", 5000);
@@ -43,8 +37,6 @@ describe("Vehicle API", function() {
 		waitsFor(function() {
 			return !!boundVehicleService;
 		}, "The found Vehicle service couldn't be bound", 5000);
-
-		
 	});
 
 	it("should be available from the discovery", function() {
@@ -52,18 +44,12 @@ describe("Vehicle API", function() {
 	});
 
 	it("has the necessary properties as service object", function() {
-		expect(vehicleService).toHaveProp("state");
-		expect(vehicleService).toHaveProp("api");
+		expect(vehicleService.state).toBeDefined();
 		expect(vehicleService.api).toEqual(jasmine.any(String));
-		expect(vehicleService).toHaveProp("id");
 		expect(vehicleService.id).toEqual(jasmine.any(String));
-		expect(vehicleService).toHaveProp("displayName");
 		expect(vehicleService.displayName).toEqual(jasmine.any(String));
-		expect(vehicleService).toHaveProp("description");
 		expect(vehicleService.description).toEqual(jasmine.any(String));
-		expect(vehicleService).toHaveProp("icon");
 		expect(vehicleService.icon).toEqual(jasmine.any(String));
-		expect(vehicleService).toHaveProp("bindService");
 		expect(vehicleService.bindService).toEqual(jasmine.any(Function));
 	});
 
@@ -85,11 +71,8 @@ describe("Vehicle API", function() {
 	});
 
 	it("has the necessary properties and functions as Vehicle API service", function() {
-		expect(boundVehicleService).toHaveProp("addEventListener");
 		expect(boundVehicleService.addEventListener).toEqual(jasmine.any(Function));
-		expect(boundVehicleService).toHaveProp("removeEventListener");
 		expect(boundVehicleService.removeEventListener).toEqual(jasmine.any(Function));
-		expect(boundVehicleService).toHaveProp("get");
 		expect(boundVehicleService.get).toEqual(jasmine.any(Function));
 		
 		//currently not implemented functions


### PR DESCRIPTION
Remove all of the self defined matchers like toHaveProp, toBeFunction,
etc. and use the ones provided by jamsine. Don't run findServices for
each spec, instead do it once for the main suite and use that one for all
specs.

Jira-issue: http://jira.webinos.org/browse/WP-725
