### PR TITLE
Add grunt.bat

### DIFF
--- a/grunt.bat
+++ b/grunt.bat
@@ -1,0 +1,2 @@
+@echo off
+grunt.cmd %*


### PR DESCRIPTION
On Windows this fixes the need to call grunt.cmd. Instead of trying to
execute the grunt.js file as if it were an executable it will now
execute the batch instead which calls grunt.

Jira-issue: http://jira.webinos.org/browse/WP-202
