### PR TITLE
Ignore IntelliJ IDEA project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,12 @@ reports
 # allow eclipse project files in linux-specific folders.
 !webinos/platform/linux/*/*.project
 
+# intellij idea project files
+.idea
+*.iml
+*.ipr
+*.iws
+
 # vstudio prj files
 *.sln
 *.vcxproj*


### PR DESCRIPTION
Added rules for git to ignore IntelliJ Idea project files.
It ignores both project formats (Directory based -.idea, .iml- and File based -.ipr, .iws, .iml-)

Jira issue: WP-726
