### PR TITLE
Fix unwatch and remove for appstate sync

### DIFF
--- a/webinos/core/wrt/lib/webinos.appstatesync.js
+++ b/webinos/core/wrt/lib/webinos.appstatesync.js
@@ -177,13 +177,11 @@
 				if (errorCallback) errorCallback({"message": "couldn't remove, already removed?"});
 				return;
 			}
-			chan.chan.disconnect(function() {
-				successCallback();
-			});
-			chan.ref--;
-			if (chan.ref === 0) {
-				delete _chanMap[id];
-			}
+			chan.chan.disconnect();
+
+			if (chan.ref > 0) chan.ref--;
+			if (chan.ref === 0) delete _chanMap[id];
+
 			successCallback();
 		};
 
@@ -255,6 +253,8 @@
 					errorCallback({message: 'not connected'});
 					return;
 				}
+
+				delete _watchMap[id+prop];
 			};
 		}
 

--- a/webinos/web_root/tests/api_tests/appstatesync/2ndsyncapp.js
+++ b/webinos/web_root/tests/api_tests/appstatesync/2ndsyncapp.js
@@ -1,17 +1,51 @@
-
 var objTemplate = {
 	"prop0": "nop"
 };
 
-webinos.sync.create("_testObjIdOtherApp", function(syncObj) {
-	console.log("created test sync object in other app");
+var syncObj;
 
-	syncObj.data.prop0 = "baz";
-	
+var msgHandlers = {
+	create: create,
+	setprop: setprop,
+	remove: remove
+};
+
+function create(objid) {
+	webinos.sync.create(objid, function(so) {
+		console.log("created test sync object in other app");
+		syncObj = so;
+		window.parent.postMessage("created:", "*");
+
+	}, function(err) {
+		console.log(err);
+	}, { // options
+		referenceObject: objTemplate
+	});
+}
+
+function setprop(val) {
+	if (!syncObj) {
+		console.log("couldn't set prop, no sync object");
+		return;
+	}
+	syncObj.data.prop0 = val;
 	console.log("set prop on sync object in other app");
+}
 
-}, function(err) {
-	console.log(err);
-}, { // options
-	referenceObject: objTemplate
-});
+function remove(objid) {
+	webinos.sync.remove(objid, function() {
+		window.parent.postMessage("removed:", "*");
+	});
+}
+
+function messageHandler(event) {
+	var msg = event.data;
+	var i = msg.indexOf(":");
+	var h = msg.slice(0, i);
+	var p = msg.slice(i + 1);
+
+	var handler = msgHandlers[h];
+	if (handler) handler(p);
+}
+
+window.addEventListener("message", messageHandler, false);


### PR DESCRIPTION
Unwatchig a property on a sync object now removes the watch listener.
Also fix reference counting for sync object. Reflect changes in updated
tests.

Jira-issue: WP-235
