### PR TITLE
Fix PZH message handling

### DIFF
--- a/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
+++ b/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
@@ -225,7 +225,7 @@ var Pzh = function () {
     this.handleData = function (_conn, _buffer) {
         try {
             _conn.pause ();
-            util.webinosMsgProcessing.readJson (self, _buffer, function (obj) {
+            util.webinosMsgProcessing.readJson (self.pzh_state.sessionId, _buffer, function (obj) {
                 self.pzh_otherManager.processMsg (obj);
             });
         } catch (err) {

--- a/webinos/core/util/lib/messageProcessing.js
+++ b/webinos/core/util/lib/messageProcessing.js
@@ -49,35 +49,37 @@ ProcessWebinosMsg.readJson = function(instance, buffer, objectHandler) {
     var jsonStr;
     var len;
     var offset = 0;
+    var accumulator;
 
     for (;;) {
         var readByteLen;
-        if (instanceMap[instance]) {
+        if (instance in instanceMap) {
             // we already read from a previous buffer, read the rest
             len = instanceMap[instance].restLen;
-            var jsonStrTmp = buffer.toString('utf8', offset, offset + len);
-            readByteLen = Buffer.byteLength(jsonStrTmp, 'utf8');
-            jsonStr = instanceMap[instance].part + jsonStrTmp;
-            offset += len;
-            instanceMap[instance] = undefined;
-
+            readByteLen = (offset + len < buffer.length) ? len : (buffer.length - offset);
+            var tmpBuffer = buffer.slice(offset,offset + readByteLen);
+            accumulator = Buffer.concat([instanceMap[instance].part, tmpBuffer], readByteLen + instanceMap[instance].part.length);
+            offset += readByteLen;
+            delete instanceMap[instance];
         } else {
             len = buffer.readUInt32LE(offset);
             offset += 4;
-            jsonStr = buffer.toString('utf8', offset, offset + len);
-            readByteLen = Buffer.byteLength(jsonStr, 'utf8');
-            offset += len;
+            readByteLen = (offset + len < buffer.length) ? len : (buffer.length - offset);
+            accumulator = new Buffer(readByteLen);
+            buffer.copy(accumulator,0,offset,offset + readByteLen);
+            offset += readByteLen;
         }
 
         if (readByteLen < len) {
             instanceMap[instance] = {
                 restLen: len - readByteLen,
-                part: jsonStr
+                part: accumulator
             };
             return;
         }
 
         // call handler with parsed message object
+        jsonStr = accumulator.toString('utf8');
         objectHandler(JSON.parse(jsonStr));
 
         if (offset >= buffer.length) {


### PR DESCRIPTION
Messages are read from the buffer using an object as a key to match partially received message chunks. This doesn't work as expected since using objects as keys results in messages getting mixed up (all objects resolve to the same key).

Also, the message processing method could result in unicode data getting corrupted.

http://jira.webinos.org/browse/WP-737
