### PR TITLE
Support for PAPE extension in the PZH Web Interface.

### DIFF
--- a/webinos/core/pzhweb/app.js
+++ b/webinos/core/pzhweb/app.js
@@ -194,7 +194,9 @@ PzhProviderWeb.startWebServer = function (host, address, port, config, cb) {
         //   callback with a user object.
         passport.use(new GoogleStrategy({
                 returnURL:serverUrl + '/auth/google/return',
-                realm:serverUrl + '/'
+                realm:serverUrl + '/',
+                profile:true,
+                pape:{ 'maxAuthAge' : 0 }
             },
             function (identifier, profile, done) {
                 "use strict";
@@ -215,7 +217,9 @@ PzhProviderWeb.startWebServer = function (host, address, port, config, cb) {
 
         passport.use(new YahooStrategy({
                 returnURL:serverUrl + '/auth/yahoo/return',
-                realm:serverUrl + '/'
+                realm:serverUrl + '/',
+                profile:true,
+                pape:{ 'maxAuthAge' : 0 }
             },
             function (identifier, profile, done) {
                 "use strict";


### PR DESCRIPTION
http://jira.webinos.org/browse/WP-92

The PZH Web Interface now implements the OpenID Provider
Authentication Policy Extension (PAPE) and sets the maximum
authentication age to '0', requiring users to re-enter their
password when logging into the PZH and preventing the
OpenID provider from caching authentication information.

PAPE details: 
http://openid.net/specs/openid-provider-authentication-policy-extension-1_0.html

Jira issue: WP-92
