### PR TITLE
Wp 263 device friendly name mapping

### DIFF
--- a/webinos/core/api/contacts/lib/contacts_modules.js
+++ b/webinos/core/api/contacts/lib/contacts_modules.js
@@ -20,7 +20,6 @@
 var webinos = require("find-dependencies")(__dirname);
 var fs = require("fs");
 var path = require("path");
-var sessionID = webinos.global.require (webinos.global.pzp.location).getSessionId();
 var wPath = webinos.global.require (webinos.global.pzp.location).getWebinosPath();
 
 var local_contacts = '';
@@ -115,7 +114,8 @@ function makeW3Ccontacts(successCB, errorCB)
 {
     var contacts_l;
     var rawContacts;
-    var pzpJsonPath = wPath + "/userData/" + sessionID + ".json";
+    var wID = webinos.global.require (webinos.global.pzp.location).getDeviceName();
+    var pzpJsonPath = wPath + "/userData/" + wID + ".json";
     var pzp_json = require(pzpJsonPath);
     if ( !pzp_json.abook || pzp_json.abook === "")
     {

--- a/webinos/core/api/contacts/lib/google_contacts.js
+++ b/webinos/core/api/contacts/lib/google_contacts.js
@@ -112,41 +112,44 @@ function newContact(i, item, picture, callback)
 	{
 		if (item['gd$structuredPostalAddress'].length !== undefined) //if is an array
 		{
-            for (j=0; j<item['gd$email'].length; j++)
-			{
-                if (formatted = item['gd$structuredPostalAddress'][j]['gd$formattedAddress'])
+            if (item['gd$email'] && item['gd$email'].length) //if email is defined
+            {
+                for (j=0; j<item['gd$email'].length; j++)
                 {
-                    formatted = item['gd$structuredPostalAddress'][j]['gd$formattedAddress']["$t"];
-                }
-				type = 'other';
-				if(item['gd$structuredPostalAddress'][j].rel !==undefined)
-                {
-                    type = item['gd$structuredPostalAddress'][j].rel.substr(('http://schemas.google.com/g/2005#').length);
-                }
-                if(item['gd$structuredPostalAddress'][j]['gd$street'])
-                {
-                    street = item['gd$structuredPostalAddress'][j]['gd$street']["$t"];
-                }
-                j==0?pref=true:pref=false;
-                if(item['gd$structuredPostalAddress'][j]['gd$city'])
-                {
-                    locality = item['gd$structuredPostalAddress'][j]['gd$city']["$t"];
-                }
-                if(item['gd$structuredPostalAddress'][j]['gd$region'])
-                {
-                    region = item['gd$structuredPostalAddress'][j]['gd$region']["$t"];
-                }
-                if(item['gd$structuredPostalAddress'][j]['gd$postcode'])
-                {
-                    postCode = item['gd$structuredPostalAddress'][j]['gd$postcode']["$t"];
-                }
-                if(item['gd$structuredPostalAddress'][j]['gd$country'])
-                {
-                    country = item['gd$structuredPostalAddress'][j]['gd$country']["$t"];
-                }
+                    if (formatted = item['gd$structuredPostalAddress'][j]['gd$formattedAddress'])
+                    {
+                        formatted = item['gd$structuredPostalAddress'][j]['gd$formattedAddress']["$t"];
+                    }
+                    type = 'other';
+                    if(item['gd$structuredPostalAddress'][j].rel !==undefined)
+                    {
+                        type = item['gd$structuredPostalAddress'][j].rel.substr(('http://schemas.google.com/g/2005#').length);
+                    }
+                    if(item['gd$structuredPostalAddress'][j]['gd$street'])
+                    {
+                        street = item['gd$structuredPostalAddress'][j]['gd$street']["$t"];
+                    }
+                    j==0?pref=true:pref=false;
+                    if(item['gd$structuredPostalAddress'][j]['gd$city'])
+                    {
+                        locality = item['gd$structuredPostalAddress'][j]['gd$city']["$t"];
+                    }
+                    if(item['gd$structuredPostalAddress'][j]['gd$region'])
+                    {
+                        region = item['gd$structuredPostalAddress'][j]['gd$region']["$t"];
+                    }
+                    if(item['gd$structuredPostalAddress'][j]['gd$postcode'])
+                    {
+                        postCode = item['gd$structuredPostalAddress'][j]['gd$postcode']["$t"];
+                    }
+                    if(item['gd$structuredPostalAddress'][j]['gd$country'])
+                    {
+                        country = item['gd$structuredPostalAddress'][j]['gd$country']["$t"];
+                    }
 
-				addrs.push(new ContactAddress(formatted, type, street, pref, locality, region, postCode, country));
-			}
+                    addrs.push(new ContactAddress(formatted, type, street, pref, locality, region, postCode, country));
+                }
+            }
 		}
 		else
 		//single address

--- a/webinos/core/api/servicedisco/lib/rpc_servicedisco.js
+++ b/webinos/core/api/servicedisco/lib/rpc_servicedisco.js
@@ -267,7 +267,7 @@
 	 * @param address Remove all services for this address.
 	 */
 	Discovery.prototype.removeRemoteServiceObjects = function(address) {
-		var count = this.remoteServiceObjects[address].length;
+		var count = this.remoteServiceObjects[address] && this.remoteServiceObjects[address].length;
 		delete this.remoteServiceObjects[address];
 		logger.log("removeRemoteServiceObjects: removed " + count + " services from: " + address);
 	};

--- a/webinos/core/manager/synchronisation_manager/index.js
+++ b/webinos/core/manager/synchronisation_manager/index.js
@@ -53,7 +53,7 @@ var Sync = function () {
         var myKey, diff = {}, update, update1, syncdata, updatedData = {};
         for( myKey in jsonObject) {
             if (jsonObject.hasOwnProperty(myKey) && remoteJsonObject.hasOwnProperty(myKey)) {
-                update = sync_.detectUpdates(jsonObject[myKey], jsonObject[myKey]);
+                update = sync_.detectUpdates(jsonObject[myKey], {});
                 update1 = sync_.detectUpdates(jsonObject[myKey], remoteJsonObject[myKey]);
                 syncdata = sync_.reconcile([update1, update]);
                 sync_.applyCommands(jsonObject[myKey], syncdata.propagations[0]);

--- a/webinos/core/pzh/lib/pzh_otherManager.js
+++ b/webinos/core/pzh/lib/pzh_otherManager.js
@@ -72,8 +72,8 @@ var Pzh_RPC = function (_parent) {
      */
     this.sendFoundServices = function (validMsgObj) {
         _parent.pzh_state.logger.log ("trying to send webinos services from this RPC handler to " + validMsgObj.from + "...");
-        var services = self.discovery.getAllServices (validMsgObj.from);
-        var msg = _parent.prepMsg (_parent.pzh_state.sessionId, validMsgObj.from, "foundServices", services);
+        var services = self.discovery.getAllServices(validMsgObj.from);
+        var msg = _parent.prepMsg(_parent.pzh_state.sessionId, validMsgObj.from, "foundServices", services);
         msg.payload.id = validMsgObj.payload.message.id;
         _parent.sendMessage (msg, validMsgObj.from);
         _parent.pzh_state.logger.log ("sent " + (services && services.length) || 0 + " Webinos Services from this rpc handler.");
@@ -178,7 +178,8 @@ var Pzh_RPC = function (_parent) {
                 switch (validMsgObj.payload.status) {
                     case "registerServices":
                         self.discovery.addRemoteServiceObjects (validMsgObj.payload.message);
-                        sendUpdateServiceToAllPzh (validMsgObj.from);
+                        _parent.pzh_state.connectedPzp[validMsgObj.from].friendlyName = validMsgObj.payload.message.friendlyName;
+                        sendUpdateServiceToAllPzh(validMsgObj.from);
                         break;
                     case "findServices":
                         self.sendFoundServices (validMsgObj);

--- a/webinos/core/pzh/lib/pzh_otherManager.js
+++ b/webinos/core/pzh/lib/pzh_otherManager.js
@@ -64,15 +64,17 @@ var Pzh_RPC = function (_parent) {
             _parent.pzh_state.connectedPzp[validMsgObj.from].friendlyName = validMsgObj.payload.message.friendlyName;
         }
         // These are friendlyName... Just for display purpose
-        for (i = 0; i < validMsgObj.payload.message.connectedPzp.length; i = i +1) {
+        for (i = 0; i < validMsgObj.payload.message.connectedPzp.length; i = i + 1) {
             if(!_parent.pzh_state.connectedPzp.hasOwnProperty(validMsgObj.payload.message.connectedPzp[i].key)) {
-                _parent.pzh_state.connectedDevicesToOtherPzh.pzp.push(validMsgObj.payload.message.connectedPzp[i]);
+                _parent.pzh_state.connectedDevicesToOtherPzh.pzp[validMsgObj.payload.message.connectedPzp[i].key] =
+                    validMsgObj.payload.message.connectedPzp[i].friendlyName || undefined;
             }
         }
-        for (i = 0; i < validMsgObj.payload.message.connectedPzh.length; i = i +1) {
+        for (i = 0; i < validMsgObj.payload.message.connectedPzh.length; i = i + 1) {
             if(!_parent.pzh_state.connectedPzh.hasOwnProperty(validMsgObj.payload.message.connectedPzh[i].key) &&
-                (validMsgObj.payload.message.connectedPzh[i].key) !== _parent.pzh_state.sessionId) {
-                _parent.pzh_state.connectedDevicesToOtherPzh.pzh.push(validMsgObj.payload.message.connectedPzh[i]);
+                validMsgObj.payload.message.connectedPzh[i].key !== _parent.pzh_state.sessionId ) {
+                _parent.pzh_state.connectedDevicesToOtherPzh.pzh[validMsgObj.payload.message.connectedPzh[i].key] =
+                    validMsgObj.payload.message.connectedPzh[i].friendlyName || undefined;
             }
         }
 

--- a/webinos/core/pzh/lib/pzh_otherManager.js
+++ b/webinos/core/pzh/lib/pzh_otherManager.js
@@ -56,11 +56,9 @@ var Pzh_RPC = function (_parent) {
 
     function updateDeviceInfo(validMsgObj) {
         var i;
-        if (_parent.pzh_state.connectedPzh[validMsgObj.from]
-            && !_parent.pzh_state.connectedPzh[validMsgObj.from].friendlyName) {
+        if (_parent.pzh_state.connectedPzh[validMsgObj.from]) {
             _parent.pzh_state.connectedPzh[validMsgObj.from].friendlyName = validMsgObj.payload.message.friendlyName;
-        } else if (_parent.pzh_state.connectedPzp[validMsgObj.from]
-            && !_parent.pzh_state.connectedPzp[validMsgObj.from].friendlyName) {
+        } else if (_parent.pzh_state.connectedPzp[validMsgObj.from]) {
             _parent.pzh_state.connectedPzp[validMsgObj.from].friendlyName = validMsgObj.payload.message.friendlyName;
         }
         // These are friendlyName... Just for display purpose

--- a/webinos/core/pzh/lib/pzh_otherManager.js
+++ b/webinos/core/pzh/lib/pzh_otherManager.js
@@ -75,6 +75,9 @@ var Pzh_RPC = function (_parent) {
                 _parent.pzh_state.connectedDevicesToOtherPzh.pzh.push(validMsgObj.payload.message.connectedPzh[i]);
             }
         }
+
+        _parent.sendUpdateToAll(validMsgObj.from);
+
     }
     /**
      * Initialize RPC to enable discovery and rpcHandler
@@ -227,7 +230,7 @@ var Pzh_RPC = function (_parent) {
                 try {
                     self.messageHandler.onMessageReceived (validMsgObj, validMsgObj.to);
                 } catch (err2) {
-                    _parent.pzh_state.logger.error ("error message sending to messaging " + err2.message);
+                    _parent.pzh_state.logger.error ("error processing message in messaging manager - " + err2.message);
                 }
             }
         });

--- a/webinos/core/pzh/lib/pzh_otherManager.js
+++ b/webinos/core/pzh/lib/pzh_otherManager.js
@@ -73,7 +73,7 @@ var Pzh_RPC = function (_parent) {
     this.sendFoundServices = function (validMsgObj) {
         _parent.pzh_state.logger.log ("trying to send webinos services from this RPC handler to " + validMsgObj.from + "...");
         var services = self.discovery.getAllServices(validMsgObj.from);
-        var msg = _parent.prepMsg(_parent.pzh_state.sessionId, validMsgObj.from, "foundServices", services);
+        var msg = _parent.prepMsg(validMsgObj.from, "foundServices", services);
         msg.payload.id = validMsgObj.payload.message.id;
         _parent.sendMessage (msg, validMsgObj.from);
         _parent.pzh_state.logger.log ("sent " + (services && services.length) || 0 + " Webinos Services from this rpc handler.");
@@ -136,7 +136,7 @@ var Pzh_RPC = function (_parent) {
 
             for (myKey in _parent.pzh_state.connectedPzp) {
                 if (_parent.pzh_state.connectedPzp.hasOwnProperty (myKey)) { // Sync with everyone.
-                    msg = _parent.prepMsg (_parent.pzh_state.sessionId, myKey, "sync_hash", result);
+                    msg = _parent.prepMsg (myKey, "sync_hash", result);
                     _parent.sendMessage (msg, myKey);
                 }
             }
@@ -158,7 +158,7 @@ var Pzh_RPC = function (_parent) {
                 //_parent.config.cert.external = receivedMsg[msg];
                 //_parent.config.storeCertificate(_parent.config.cert.external, "external");
             }
-            var msg = _parent.prepMsg (_parent.pzh_state.sessionId, _pzpId, "update_hash", result);
+            var msg = _parent.prepMsg (_pzpId, "update_hash", result);
             _parent.sendMessage (msg, _pzpId);
         }
         else {

--- a/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
+++ b/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
@@ -52,7 +52,7 @@ var Pzh = function () {
         list = (type === "pzp") ? self.pzh_state.connectedDevicesToOtherPzh.pzp:self.pzh_state.connectedDevicesToOtherPzh.pzh;
         for (key in list) {
             if (list.hasOwnProperty(key)) {
-                connList.push({friendlyName: list[key].friendlyName, key: key});
+                connList.push({friendlyName: list[key], key: key});
             }
         }
         return connList;

--- a/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
+++ b/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
@@ -38,28 +38,34 @@ var Pzh = function () {
         connectedPzp:{}, // Holds connected PZP information such as IP address and socket connection
         connectedPzh:{},
         expecting   :"", // Set by auth-code directly
-        logger      :logging (__filename)
+        logger      :logging (__filename),
+        connectedDevicesToOtherPzh: {pzh:[], pzp:[]}
     };
 
-    function sendUpdateToPzp() {
-        function getConnectedList(type) {
-            var connList=[], key, list = (type === "pzp") ? self.pzh_state.connectedPzp: self.pzh_state.connectedPzh;
-            for (key in list) {
-                if (list.hasOwnProperty(key) && list[key].friendlyName) {
-                    connList.push(list[key].friendlyName || key);
-                }
+    function getConnectedList(type) {
+        var connList=[], key, list = (type === "pzp") ? self.pzh_state.connectedPzp: self.pzh_state.connectedPzh;
+        for (key in list) {
+            if (list.hasOwnProperty(key)) {
+                connList.push({friendlyName: list[key].friendlyName, key: key});
             }
-            return connList;
         }
+        return connList;
+    }
+    function sendUpdateToAll() {
+        var key, msg, payload = {friendlyName: self.config.metaData.friendlyName,
+            connectedPzp: getConnectedList("pzp"),
+            connectedPzh: getConnectedList("pzh")};
 
-        var key, msg;
         for (key in self.pzh_state.connectedPzp) {
             if (self.pzh_state.connectedPzp.hasOwnProperty(key)) {
-                msg = self.prepMsg(key, "update",
-                    {friendlyName: self.config.metaData.friendlyName,
-                        connectedPzp: getConnectedList("pzp"),
-                        connectedPzh: getConnectedList("pzh")})
-               self.sendMessage (msg, key);
+                msg = self.prepMsg(key, "update", payload);
+                self.sendMessage (msg, key);
+            }
+        }
+        for (key in self.pzh_state.connectedPzh) {
+            if (self.pzh_state.connectedPzh.hasOwnProperty(key)) {
+                msg = self.prepMsg(key, "update", payload);
+                self.sendMessage (msg, key);
             }
         }
     }
@@ -85,7 +91,7 @@ var Pzh = function () {
             _conn.id = _pzpId;
             msg = self.pzh_otherManager.messageHandler.registerSender (self.pzh_state.sessionId, _pzpId);
             self.sendMessage (msg, _pzpId);
-            sendUpdateToPzp();
+            sendUpdateToAll();
             self.pzh_otherManager.syncStart(_pzpId);
         } else {
             logger.error ("unknown pzp " + _pzpId + " trying to connect")
@@ -110,10 +116,9 @@ var Pzh = function () {
                 _conn.id = _pzhId;
 
                 setTimeout (function () {
-                    msg = self.pzh_otherManager.messageHandler.registerSender (self.config.metaData.serverName, _pzhId);
-                    msg.payload = self.config.metaData.friendlyName;
+                    msg = self.pzh_otherManager.messageHandler.registerSender(self.config.metaData.serverName, _pzhId);
                     self.sendMessage (msg, _pzhId);
-                    sendUpdateToPzp();
+                    sendUpdateToAll();
                     self.pzh_otherManager.registerServices (_pzhId);
                 }, 3000);
             } else {
@@ -273,7 +278,7 @@ var Pzh = function () {
             self.pzh_otherManager.messageHandler.removeRoute (_id, self.config.metaData.serverName);
             delete self.pzh_state.connectedPzh[_id];
         }
-        sendUpdateToPzp();
+        sendUpdateToAll();
         self.pzh_otherManager.discovery.removeRemoteServiceObjects (_id);
     };
     /**
@@ -317,12 +322,12 @@ var Pzh = function () {
 };
 module.exports = Pzh;
 
-var Pzh_Pzh = function (_parent) {
+var Pzh_Pzh = function (parent) {
     var self = this;
     this.connect_ConnectedPzh = function (options) {
         var myKey;
-        for (myKey in  _parent.config.trustedList.pzh) {
-            if (!_parent.pzh_state.connectedPzh.hasOwnProperty (myKey) && _parent.pzh_state.sessionId !== myKey) {
+        for (myKey in  parent.config.trustedList.pzh) {
+            if (!parent.pzh_state.connectedPzh.hasOwnProperty (myKey) && parent.pzh_state.sessionId !== myKey) {
                 self.connectOtherPZH (myKey, options);
             }
         }
@@ -330,7 +335,7 @@ var Pzh_Pzh = function (_parent) {
 
     this.connectOtherPZH = function (_to, _options) {
         try {
-            var pzhDetails = _parent.config.cert.external[_to];
+            var pzhDetails = parent.config.cert.external[_to];
             var connPzh, connDetails;
             var tls = require ("tls"), host = pzhDetails.host;
             if (parseInt (pzhDetails.port) !== 443) {
@@ -340,33 +345,33 @@ var Pzh_Pzh = function (_parent) {
             connDetails.servername = _to;
             connDetails.host = pzhDetails.host;
             connDetails.port = pzhDetails.serverPort; //parseInt(pzhDetails.port);
-            _parent.pzh_state.logger.log ("connection from " + _parent.pzh_state.sessionId + " - to " + connDetails.servername + " initiated");
-            _parent.pzh_state.logger.log ("connection at " + connDetails.host + " and port " + connDetails.port);
+            parent.pzh_state.logger.log ("connection from " + parent.pzh_state.sessionId + " - to " + connDetails.servername + " initiated");
+            parent.pzh_state.logger.log ("connection at " + connDetails.host + " and port " + connDetails.port);
             connPzh = tls.connect (connDetails, function () {
-                _parent.pzh_state.logger.log ("connection status : " + connPzh.authorized);
+                parent.pzh_state.logger.log ("connection status : " + connPzh.authorized);
                 if (connPzh.authorized) {
-                    _parent.pzh_state.logger.log ("connected to " + _to);
-                    _parent.handlePzhAuthorization (_to, connPzh);
+                    parent.pzh_state.logger.log ("connected to " + _to);
+                    parent.handlePzhAuthorization (_to, connPzh);
                 } else {
-                    _parent.pzh_state.logger.error ("connection authorization Failed - " + connPzh.authorizationError);
+                    parent.pzh_state.logger.error ("connection authorization Failed - " + connPzh.authorizationError);
                 }
             });
             connPzh.on ("data", function (buffer) {
-                _parent.handleData (connPzh, buffer);
+                parent.handleData (connPzh, buffer);
             });
             connPzh.on ("error", function (err) {
-                _parent.pzh_state.logger.error (err.message);
+                parent.pzh_state.logger.error (err.message);
             });
             connPzh.on ("end", function () {
-                _parent.removeRoute (connPzh.id);
+                parent.removeRoute (connPzh.id);
             });
         } catch (err) {
-            _parent.pzh_state.logger.error ("connecting other pzh failed in setting configuration " + err);
+            parent.pzh_state.logger.error ("connecting other pzh failed in setting configuration " + err);
         }
     };
 };
 
-var RevokePzp = function (_parent) {
+var RevokePzp = function (parent) {
     /**
      * Removes a PZP from the PZH
      * @param _pzpid
@@ -374,33 +379,33 @@ var RevokePzp = function (_parent) {
      * @param _callback
      */
     this.revokeCert = function (_pzpid, _refreshCert, _callback) {
-        var pzpCert = _parent.config.cert.internal.signedCert[_pzpid];
-        _parent.config.revokeClientCert (pzpCert, function (status, crl) {
+        var pzpCert = parent.config.cert.internal.signedCert[_pzpid];
+        parent.config.revokeClientCert (pzpCert, function (status, crl) {
             if (status) {
-                _parent.pzh_state.logger.log ("revocation success! " + _pzpid + " should not be able to connect anymore ");
-                _parent.config.crl = crl;
-                delete _parent.config.cert.internal.signedCert[_pzpid];
-                delete _parent.config.trustedList.pzp[_pzpid];
-                _parent.config.cert.internal.revokedCert[_pzpid] = crl;
-                _parent.config.storeAll ();
-                if (_parent.pzh_state.connectedPzp[_pzpid]) {
-                    _parent.pzh_state.connectedPzp[_pzpid].socket.end ();
-                    delete _parent.pzh_state.connectedPzp[_pzpid];
+                parent.pzh_state.logger.log ("revocation success! " + _pzpid + " should not be able to connect anymore ");
+                parent.config.crl = crl;
+                delete parent.config.cert.internal.signedCert[_pzpid];
+                delete parent.config.trustedList.pzp[_pzpid];
+                parent.config.cert.internal.revokedCert[_pzpid] = crl;
+                parent.config.storeAll ();
+                if (parent.pzh_state.connectedPzp[_pzpid]) {
+                    parent.pzh_state.connectedPzp[_pzpid].socket.end ();
+                    delete parent.pzh_state.connectedPzp[_pzpid];
                 }
-                _parent.setConnParam (function (status, options) {
+                parent.setConnParam (function (status, options) {
                     if (status) {
-                        _refreshCert (_parent.config.metaData.serverName, options);
+                        _refreshCert (parent.config.metaData.serverName, options);
                     }
                 });
-                _callback ({cmd:"revokePzp", to:_parent.config.metaData.serverName, payload:_pzpid});
+                _callback ({cmd:"revokePzp", to:parent.config.metaData.serverName, payload:_pzpid});
             } else {
-                _callback ({cmd:"revokePzp", to:_parent.config.metaData.serverName, payload:"failed"});
+                _callback ({cmd:"revokePzp", to:parent.config.metaData.serverName, payload:"failed"});
             }
         });
     };
 };
 
-var AddPzp = function (_parent) {
+var AddPzp = function (parent) {
     /**
      * Adds new PZP certificate. This is triggered by client, which sends its csr certificate and PZH signs
      * certificate and return backs a signed PZP certificate.
@@ -409,41 +414,42 @@ var AddPzp = function (_parent) {
      */
     this.addNewPZPCert = function (_msgRcvd, _callback) {
         try {
-            var pzpId = _parent.pzh_state.sessionId + "/" + _msgRcvd.message.from, msg;
-            if (_parent.config.cert.internal.revokedCert[pzpId]) {
-                msg = _parent.prepMsg(pzpId, "error", "pzp was previously revoked");
+            var pzpId = parent.pzh_state.sessionId + "/" + _msgRcvd.message.from, msg;
+            if (parent.config.cert.internal.revokedCert[pzpId]) {
+                msg = parent.prepMsg(pzpId, "error", "pzp was previously revoked");
                 _callback (false, msg);
                 return;
             }
-            _parent.pzh_state.expecting.isExpectedCode (_msgRcvd.message.code, function (expected) { // Check QRCode if it is valid ..
+            parent.pzh_state.expecting.isExpectedCode (_msgRcvd.message.code, function (expected) { // Check QRCode if it is valid ..
                 if (expected) {
-                    _parent.config.generateSignedCertificate (_msgRcvd.message.csr, 2, function (status, value) { // Sign certificate based on received csr from client.// pzp = 2
+                    parent.config.generateSignedCertificate (_msgRcvd.message.csr, 2, function (status, value) { // Sign certificate based on received csr from client.// pzp = 2
                         if (status) { // unset expected QRCode
-                            _parent.config.cert.internal.signedCert[pzpId] = value;
-                            _parent.pzh_state.expecting.unsetExpected (function () {
-                                _parent.config.storeCertificate (_parent.config.cert.internal, "internal");
-                                if (!_parent.config.trustedList.pzp.hasOwnProperty (pzpId)) {// update configuration with signed certificate details ..
-                                    _parent.config.trustedList.pzp[pzpId] = {addr:"", port:""};
-                                    _parent.config.storeTrustedList (_parent.config.trustedList);
+                            parent.config.cert.internal.signedCert[pzpId] = value;
+                            parent.pzh_state.expecting.unsetExpected (function () {
+                                parent.config.storeCertificate (parent.config.cert.internal, "internal");
+                                if (!parent.config.trustedList.pzp.hasOwnProperty (pzpId)) {// update configuration with signed certificate details ..
+                                    parent.config.trustedList.pzp[pzpId] = {addr:"", port:""};
+                                    parent.config.storeTrustedList (parent.config.trustedList);
                                 }
-                                var payload = {"clientCert":_parent.config.cert.internal.signedCert[pzpId],
-                                    "masterCert"           :_parent.config.cert.internal.master.cert, "masterCrl":_parent.config.crl};// Send signed certificate and master certificate to PZP
-                                msg = _parent.prepMsg(pzpId, "signedCertByPzh", payload);
+                                var payload = {"clientCert":parent.config.cert.internal.signedCert[pzpId],
+                                    "masterCert":parent.config.cert.internal.master.cert,
+                                    "masterCrl":parent.config.crl};// Send signed certificate and master certificate to PZP
+                                msg = parent.prepMsg(pzpId, "signedCertByPzh", payload);
                                 _callback (true, msg);
                             });
                         } else {
-                            msg = _parent.prepMsg(_msgRcvd.message.from, "error", value);
+                            msg = parent.prepMsg(_msgRcvd.message.from, "error", value);
                             _callback (false, msg);
                         }
                     });
                 } else {
-                    msg = _parent.prepMsg(_msgRcvd.message.from, "error", "not expecting new pzp");
+                    msg = parent.prepMsg(_msgRcvd.message.from, "error", "not expecting new pzp");
                     _callback (false, msg);// Fail message
                 }
             });
         } catch (err) {
-            _parent.pzh_state.logger.error ("error signing client certificate" + err);
-            msg = _parent.prepMsg(_msgRcvd.message.from, "error", err.message);
+            parent.pzh_state.logger.error ("error signing client certificate" + err);
+            msg = parent.prepMsg(_msgRcvd.message.from, "error", err.message);
             _callback (false, msg);
         }
     };

--- a/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
+++ b/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
@@ -39,7 +39,7 @@ var Pzh = function () {
         connectedPzh:{},
         expecting   :"", // Set by auth-code directly
         logger      :logging (__filename),
-        connectedDevicesToOtherPzh: {pzh:[], pzp:[]}
+        connectedDevicesToOtherPzh: {pzh:{}, pzp:{}}
     };
 
     function getConnectedList(type) {
@@ -50,8 +50,10 @@ var Pzh = function () {
             }
         }
         list = (type === "pzp") ? self.pzh_state.connectedDevicesToOtherPzh.pzp:self.pzh_state.connectedDevicesToOtherPzh.pzh;
-        for (key = 0; key < list.length; key = key + 1) {
-            connList.push({friendlyName: list[key].friendlyName, key: list[key].key});
+        for (key in list) {
+            if (list.hasOwnProperty(key)) {
+                connList.push({friendlyName: list[key].friendlyName, key: key});
+            }
         }
         return connList;
     }

--- a/webinos/core/pzh/lib/pzh_webSessionHandling.js
+++ b/webinos/core/pzh/lib/pzh_webSessionHandling.js
@@ -71,9 +71,13 @@ var pzhWI = function (pzhs, hostname, port, serverPort, addPzh, refreshPzh, getA
     function getConnectedPzp (_instance) {
         var i, pzps = [], list = Object.keys (_instance.config.trustedList.pzp), isConnected, id;
         for (i = 0; i < list.length; i = i + 1) {
-            isConnected = (_instance.pzh_state.connectedPzp.hasOwnProperty (list[i]))? true: false;
+            isConnected = !!(_instance.pzh_state.connectedPzp.hasOwnProperty (list[i]));
             id = (_instance.pzh_state.connectedPzp[list[i]] && _instance.pzh_state.connectedPzp[list[i]].friendlyName) || list[i];
             pzps.push ({id: id, url:list[i], isConnected:isConnected});
+        }
+        for (i = 0; i < _instance.pzh_state.connectedDevicesToOtherPzh.pzp.length; i = i + 1) {
+            pzps.push ({id: _instance.pzh_state.connectedDevicesToOtherPzh.pzp[i].friendlyName,
+                url:_instance.pzh_state.connectedDevicesToOtherPzh.pzp[i].key, isConnected:true});
         }
         return pzps;
     }
@@ -81,9 +85,13 @@ var pzhWI = function (pzhs, hostname, port, serverPort, addPzh, refreshPzh, getA
     function getConnectedPzh (_instance) {
         var pzhs = [], i, list = Object.keys (_instance.config.trustedList.pzh), isConnected, id;
         for (i = 0; i < list.length; i = i + 1) {
-            isConnected = (_instance.pzh_state.connectedPzh.hasOwnProperty (list[i]))? true: false;
+            isConnected = !!(_instance.pzh_state.connectedPzh.hasOwnProperty (list[i]));
             id =  (_instance.pzh_state.connectedPzh[list[i]] && _instance.pzh_state.connectedPzh[list[i]].friendlyName) || list[i];
             pzhs.push ({id: id, url:list[i], isConnected:isConnected});
+        }
+        for (i = 0; i < _instance.pzh_state.connectedDevicesToOtherPzh.pzh.length; i = i + 1) {
+            pzhs.push ({id: _instance.pzh_state.connectedDevicesToOtherPzh.pzh[i].friendlyName,
+                url:_instance.pzh_state.connectedDevicesToOtherPzh.pzp[i].key, isConnected:true});
         }
         pzhs.push ({id:_instance.config.metaData.friendlyName+" (Your Pzh)", url:_instance.config.metaData.serverName, isConnected:true});
         return pzhs;
@@ -450,6 +458,9 @@ var pzhWI = function (pzhs, hostname, port, serverPort, addPzh, refreshPzh, getA
             var pzhId = hostname + "_" + userId;
             if (port !== 443) {
                 pzhId = hostname + ":" + port + "_" + userId;
+            }
+            if (pzhs[pzhId]) {
+                return callback(false, "pzh id already exists");
             }
             logger.log ("adding new zone hub - " + pzhId);
             pzhs[pzhId] = new pzh_session ();

--- a/webinos/core/pzh/lib/pzh_webSessionHandling.js
+++ b/webinos/core/pzh/lib/pzh_webSessionHandling.js
@@ -75,9 +75,11 @@ var pzhWI = function (pzhs, hostname, port, serverPort, addPzh, refreshPzh, getA
             id = (_instance.pzh_state.connectedPzp[list[i]] && _instance.pzh_state.connectedPzp[list[i]].friendlyName) || list[i];
             pzps.push ({id: id, url:list[i], isConnected:isConnected});
         }
-        for (i = 0; i < _instance.pzh_state.connectedDevicesToOtherPzh.pzp.length; i = i + 1) {
-            pzps.push ({id: _instance.pzh_state.connectedDevicesToOtherPzh.pzp[i].friendlyName,
-                url:_instance.pzh_state.connectedDevicesToOtherPzh.pzp[i].key, isConnected:true});
+        for (i in _instance.pzh_state.connectedDevicesToOtherPzh.pzp) {
+            if (_instance.pzh_state.connectedDevicesToOtherPzh.pzp.hasOwnProperty(i)) {
+                pzps.push ({id: _instance.pzh_state.connectedDevicesToOtherPzh.pzp[i] || i,
+                url:i, isConnected:true});
+            }
         }
         return pzps;
     }
@@ -89,9 +91,11 @@ var pzhWI = function (pzhs, hostname, port, serverPort, addPzh, refreshPzh, getA
             id =  (_instance.pzh_state.connectedPzh[list[i]] && _instance.pzh_state.connectedPzh[list[i]].friendlyName) || list[i];
             pzhs.push ({id: id, url:list[i], isConnected:isConnected});
         }
-        for (i = 0; i < _instance.pzh_state.connectedDevicesToOtherPzh.pzh.length; i = i + 1) {
-            pzhs.push ({id: _instance.pzh_state.connectedDevicesToOtherPzh.pzh[i].friendlyName,
-                url:_instance.pzh_state.connectedDevicesToOtherPzh.pzp[i].key, isConnected:true});
+        for (i in _instance.pzh_state.connectedDevicesToOtherPzh.pzh) {
+            if (_instance.pzh_state.connectedDevicesToOtherPzh.pzh.hasOwnProperty(i)) {
+                pzps.push ({id: _instance.pzh_state.connectedDevicesToOtherPzh.pzh[i]|| i,
+                    url:i, isConnected:true});
+            }
         }
         pzhs.push ({id:_instance.config.metaData.friendlyName+" (Your Pzh)", url:_instance.config.metaData.serverName, isConnected:true});
         return pzhs;

--- a/webinos/core/pzh/lib/pzh_webSessionHandling.js
+++ b/webinos/core/pzh/lib/pzh_webSessionHandling.js
@@ -69,28 +69,23 @@ var pzhWI = function (pzhs, hostname, port, serverPort, addPzh, refreshPzh, getA
     }
 
     function getConnectedPzp (_instance) {
-        var i, pzps = [], list = Object.keys (_instance.config.trustedList.pzp);
+        var i, pzps = [], list = Object.keys (_instance.config.trustedList.pzp), isConnected, id;
         for (i = 0; i < list.length; i = i + 1) {
-            if (_instance.pzh_state.connectedPzp.hasOwnProperty (list[i])) {
-                pzps.push ({id:list[i].split ("/")[1], url:list[i], isConnected:true});
-            } else {
-                pzps.push ({id:list[i].split ("/")[1], url:list[i], isConnected:false});
-            }
+            isConnected = (_instance.pzh_state.connectedPzp.hasOwnProperty (list[i]))? true: false;
+            id = (_instance.pzh_state.connectedPzp[list[i]] && _instance.pzh_state.connectedPzp[list[i]].friendlyName) || list[i];
+            pzps.push ({id: id, url:list[i], isConnected:isConnected});
         }
         return pzps;
     }
 
     function getConnectedPzh (_instance) {
-        var pzhs = [], id, i, list = Object.keys (_instance.config.trustedList.pzh);
+        var pzhs = [], i, list = Object.keys (_instance.config.trustedList.pzh), isConnected, id;
         for (i = 0; i < list.length; i = i + 1) {
-            id = list[i].substring(list[i].indexOf("_")+1, list[i].length);
-            if (_instance.pzh_state.connectedPzh.hasOwnProperty (list[i])) {
-                pzhs.push ({id:id, url:list[i], isConnected:true});
-            } else {
-                pzhs.push ({id:id, url:list[i], isConnected:false});
-            }
+            isConnected = (_instance.pzh_state.connectedPzh.hasOwnProperty (list[i]))? true: false;
+            id =  (_instance.pzh_state.connectedPzh[list[i]] && _instance.pzh_state.connectedPzh[list[i]].friendlyName) || list[i];
+            pzhs.push ({id: id, url:list[i], isConnected:isConnected});
         }
-        pzhs.push ({id:_instance.config.userData.email[0].value + " (Your Pzh)", url:_instance.config.metaData.serverName, isConnected:true});
+        pzhs.push ({id:_instance.config.metaData.friendlyName+" (Your Pzh)", url:_instance.config.metaData.serverName, isConnected:true});
         return pzhs;
     }
 
@@ -193,7 +188,7 @@ var pzhWI = function (pzhs, hostname, port, serverPort, addPzh, refreshPzh, getA
                 sendMsg (conn, obj.user, { type:"listUnregServices",
                     message                    :{"pzEntityId":obj.message.at, "modules":modules.services} });
             });
-            var msg = userObj.prepMsg (userObj.pzh_state.sessionId, obj.message.at, "listUnregServices", {listenerId:id});
+            var msg = userObj.prepMsg (obj.message.at, "listUnregServices", {listenerId:id});
             userObj.sendMessage (msg, obj.message.at);
         } else { // returns all the current serviceCache
             var data = require ("fs").readFileSync ("./webinos_config.json");
@@ -205,7 +200,7 @@ var pzhWI = function (pzhs, hostname, port, serverPort, addPzh, refreshPzh, getA
 
     function registerService (conn, obj, userObj) {
         if (userObj.pzh_state.sessionId !== obj.message.at) {
-            var msg = userObj.prepMsg (userObj.pzh_state.sessionId, obj.message.at, "registerService",
+            var msg = userObj.prepMsg (obj.message.at, "registerService",
                 {name:obj.message.name, params:{}});
             userObj.sendMessage (msg, obj.message.at);
         } else {
@@ -221,7 +216,7 @@ var pzhWI = function (pzhs, hostname, port, serverPort, addPzh, refreshPzh, getA
 
     function unregisterService (conn, obj, userObj) {
         if (userObj.pzh_state.sessionId !== obj.message.at) {
-            var msg = userObj.prepMsg (userObj.pzh_state.sessionId, obj.message.at, "unregisterService",
+            var msg = userObj.prepMsg (obj.message.at, "unregisterService",
                 {svId:obj.message.svId, svAPI:obj.message.svAPI})
             userObj.sendMessage (msg, obj.message.at);
         } else {

--- a/webinos/core/pzp/lib/pzp_otherManager.js
+++ b/webinos/core/pzp/lib/pzp_otherManager.js
@@ -147,15 +147,13 @@ var Pzp_OtherManager = function (_parent) {
 
     function updateDeviceInfo(validMsgObj) {
         var i;
-        if (_parent.pzp_state.connectedPzh[validMsgObj.from]
-            && !_parent.pzp_state.connectedPzh[validMsgObj.from].friendlyName) {
+        if (_parent.pzp_state.connectedPzh[validMsgObj.from]) {
             _parent.pzp_state.connectedPzh[validMsgObj.from].friendlyName = validMsgObj.payload.message.friendlyName;
             if (_parent.config.metaData.friendlyName.indexOf(validMsgObj.payload.message.friendlyName) === -1) {
                 _parent.config.metaData.friendlyName = validMsgObj.payload.message.friendlyName + "'s " + _parent.config.metaData.friendlyName;
                 _parent.config.storeMetaData(_parent.config.metaData);
             }
-        } else if (_parent.pzp_state.connectedPzp[validMsgObj.from]
-            && !_parent.pzp_state.connectedPzp[validMsgObj.from].friendlyName) {
+        } else if (_parent.pzp_state.connectedPzp[validMsgObj.from]) {
             _parent.pzp_state.connectedPzp[validMsgObj.from].friendlyName = validMsgObj.payload.message.friendlyName;
         }
         // These are friendlyName... Just for display purpose

--- a/webinos/core/pzp/lib/pzp_otherManager.js
+++ b/webinos/core/pzp/lib/pzp_otherManager.js
@@ -50,34 +50,25 @@ var Pzp_OtherManager = function (_parent) {
      */
     function registerMessaging (pzhId) {
         if (_parent.pzp_state.connectedPzh[pzhId] && _parent.pzp_state.enrolled) {
-            var msg = self.messageHandler.registerSender (_parent.pzp_state.sessionId, pzhId);
+            var msg = self.messageHandler.registerSender(_parent.pzp_state.sessionId, pzhId);
             _parent.sendMessage (msg, pzhId);
         }
     }
 
-
-    function setFoundService(validMsgObj){
-        var services = self.discovery.getAllServices(validMsgObj.from);
-        var msg = {"type" : "prop",
-            "from" : _parent.pzp_state.sessionId,
-            "to"   : validMsgObj.from,
-            "payload":{"status":"foundServices",
-                "message": services,
-                "id" : validMsgObj.payload.message.id }
-        };
-        _parent.sendMessage(msg, validMsgObj.from);
-    }
-
-    function syncHash(receivedMsg) {
-        var policyPath = path.join(_parent.config.metaData.webinosRoot, "policies","policy.xml");
-        sync.parseXMLFile(policyPath, function(value) {
-            var list = {trustedList: _parent.config.trustedList, exCertList: _parent.config.exCertList, crl: _parent.config.crl, cert: _parent.config.cert.external, policy: value};
-            var result = sync.compareFileHash(list, receivedMsg);
-            if (Object.keys(result).length >= 1) {
-                _parent.prepMsg(_parent.pzp_state.sessionId, _parent.config.metaData.pzhId, "sync_compare", result);
+    function syncHash (receivedMsg) {
+        var policyPath = path.join (_parent.config.metaData.webinosRoot, "policies", "policy.xml");
+        sync.parseXMLFile (policyPath, function (value) {
+            var list = {trustedList:_parent.config.trustedList,
+                crl                :_parent.config.crl,
+                cert               :_parent.config.cert.external,
+                exCertList         : _parent.config.exCertList,
+                policy             :value};
+            var result = sync.compareFileHash (list, receivedMsg);
+            if (Object.keys (result).length >= 1) {
+                _parent.prepMsg (_parent.pzp_state.sessionId, _parent.config.metaData.pzhId, "sync_compare", result);
             }
             else {
-                logger.log("All Files are already synchronized");
+                logger.log ("All Files are already synchronized");
             }
         });
     }
@@ -195,8 +186,13 @@ var Pzp_OtherManager = function (_parent) {
         var pzhId = _parent.config.metaData.pzhId;
         if (_parent.pzp_state.connectedPzh[pzhId] && _parent.pzp_state.enrolled) {
             var localServices = self.discovery.getRegisteredServices ();
-            var msg = {"type":"prop", "from":_parent.pzp_state.sessionId, "to":pzhId, "payload":{"status":"registerServices",
-                "message"                                                                                :{services:localServices, from:_parent.pzp_state.sessionId}}};
+            var msg = {"type":"prop",
+                "from"       :_parent.pzp_state.sessionId,
+                "to"         :pzhId,
+                "payload"    :{"status":"registerServices",
+                    "message"          :{services:localServices,
+                        from                     :_parent.pzp_state.sessionId,
+                        friendlyName             :_parent.config.metaData.friendlyName}}};
             _parent.sendMessage (msg, pzhId);
             logger.log ("sent msg to register local services with pzh");
         }

--- a/webinos/core/pzp/lib/pzp_otherManager.js
+++ b/webinos/core/pzp/lib/pzp_otherManager.js
@@ -159,15 +159,19 @@ var Pzp_OtherManager = function (_parent) {
             _parent.pzp_state.connectedPzp[validMsgObj.from].friendlyName = validMsgObj.payload.message.friendlyName;
         }
         // These are friendlyName... Just for display purpose
-        for (i = 0; i < validMsgObj.payload.message.connectedPzp.length; i = i +1) {
-            if(!_parent.pzp_state.connectedPzp.hasOwnProperty(validMsgObj.payload.message.connectedPzp[i].key)&&
-            (validMsgObj.payload.message.connectedPzp[i].key) !== _parent.pzp_state.sessionId) {
-                _parent.pzp_state.connectedDevicesToPzh.pzp.push(validMsgObj.payload.message.connectedPzp[i]);
+        for (i = 0; i < validMsgObj.payload.message.connectedPzp.length; i = i + 1) {
+            if(!_parent.pzp_state.connectedPzp.hasOwnProperty(validMsgObj.payload.message.connectedPzp[i].key) &&
+                validMsgObj.payload.message.connectedPzp[i].key !== _parent.pzp_state.sessionId)
+            {
+                _parent.pzp_state.connectedDevicesToPzh.pzp[validMsgObj.payload.message.connectedPzp[i].key] =
+                    validMsgObj.payload.message.connectedPzp[i] && validMsgObj.payload.message.connectedPzp[i].friendlyName;
             }
         }
-        for (i = 0; i < validMsgObj.payload.message.connectedPzh.length; i = i +1) {
+
+        for (i = 0; i < validMsgObj.payload.message.connectedPzh.length; i = i + 1) {
             if(!_parent.pzp_state.connectedPzh.hasOwnProperty(validMsgObj.payload.message.connectedPzh[i].key)) {
-                _parent.pzp_state.connectedDevicesToPzh.pzh.push(validMsgObj.payload.message.connectedPzh[i]);
+                _parent.pzp_state.connectedDevicesToPzh.pzh[validMsgObj.payload.message.connectedPzh[i].key]=
+                    validMsgObj.payload.message.connectedPzh[i] && validMsgObj.payload.message.connectedPzh[i].friendlyName;
             }
         }
         _parent.pzpWebSocket.connectedApp();

--- a/webinos/core/pzp/lib/pzp_otherManager.js
+++ b/webinos/core/pzp/lib/pzp_otherManager.js
@@ -150,19 +150,23 @@ var Pzp_OtherManager = function (_parent) {
         if (_parent.pzp_state.connectedPzh[validMsgObj.from]
             && !_parent.pzp_state.connectedPzh[validMsgObj.from].friendlyName) {
             _parent.pzp_state.connectedPzh[validMsgObj.from].friendlyName = validMsgObj.payload.message.friendlyName;
+            if (_parent.config.metaData.friendlyName.indexOf(validMsgObj.payload.message.friendlyName) === -1) {
+                _parent.config.metaData.friendlyName = validMsgObj.payload.message.friendlyName + "'s " + _parent.config.metaData.friendlyName;
+                _parent.config.storeMetaData(_parent.config.metaData);
+            }
         } else if (_parent.pzp_state.connectedPzp[validMsgObj.from]
             && !_parent.pzp_state.connectedPzp[validMsgObj.from].friendlyName) {
             _parent.pzp_state.connectedPzp[validMsgObj.from].friendlyName = validMsgObj.payload.message.friendlyName;
         }
         // These are friendlyName... Just for display purpose
         for (i = 0; i < validMsgObj.payload.message.connectedPzp.length; i = i +1) {
-            if(!_parent.pzp_state.connectedPzp.hasOwnProperty(validMsgObj.payload.message.connectedPzp[i])&&
-            (validMsgObj.payload.message.connectedPzp[i]) !== _parent.pzp_state.sessionId) {
+            if(!_parent.pzp_state.connectedPzp.hasOwnProperty(validMsgObj.payload.message.connectedPzp[i].key)&&
+            (validMsgObj.payload.message.connectedPzp[i].key) !== _parent.pzp_state.sessionId) {
                 _parent.pzp_state.connectedDevicesToPzh.pzp.push(validMsgObj.payload.message.connectedPzp[i]);
             }
         }
         for (i = 0; i < validMsgObj.payload.message.connectedPzh.length; i = i +1) {
-            if(!_parent.pzp_state.connectedPzh.hasOwnProperty(validMsgObj.payload.message.connectedPzh[i])) {
+            if(!_parent.pzp_state.connectedPzh.hasOwnProperty(validMsgObj.payload.message.connectedPzh[i].key)) {
                 _parent.pzp_state.connectedDevicesToPzh.pzh.push(validMsgObj.payload.message.connectedPzh[i]);
             }
         }
@@ -215,9 +219,8 @@ var Pzp_OtherManager = function (_parent) {
                 "from"       :_parent.pzp_state.sessionId,
                 "to"         :pzhId,
                 "payload"    :{"status":"registerServices",
-                    "message"          :{services:localServices,
-                        from                     :_parent.pzp_state.sessionId,
-                        friendlyName             :_parent.config.metaData.friendlyName}}};
+                    "message":{services:localServices,
+                       "from":_parent.pzp_state.sessionId}}};
             _parent.sendMessage (msg, pzhId);
             logger.log ("sent msg to register local services with pzh");
         }

--- a/webinos/core/pzp/lib/pzp_otherManager.js
+++ b/webinos/core/pzp/lib/pzp_otherManager.js
@@ -170,6 +170,7 @@ var Pzp_OtherManager = function (_parent) {
                 _parent.pzp_state.connectedDevicesToPzh.pzh.push(validMsgObj.payload.message.connectedPzh[i]);
             }
         }
+        _parent.pzpWebSocket.connectedApp();
     }
 
     /**
@@ -212,18 +213,20 @@ var Pzp_OtherManager = function (_parent) {
      * Used by RPC to register and update services to the PZH
      */
     this.registerServicesWithPzh = function () {
-        var pzhId = _parent.config.metaData.pzhId;
-        if (_parent.pzp_state.connectedPzh[pzhId] && _parent.pzp_state.enrolled) {
-            var localServices = self.discovery.getRegisteredServices ();
-            var msg = {"type":"prop",
-                "from"       :_parent.pzp_state.sessionId,
-                "to"         :pzhId,
-                "payload"    :{"status":"registerServices",
-                    "message":{services:localServices,
-                       "from":_parent.pzp_state.sessionId}}};
-            _parent.sendMessage (msg, pzhId);
-            logger.log ("sent msg to register local services with pzh");
-        }
+        setTimeout(function(){   // timeout as register services takes time to load
+            var pzhId = _parent.config.metaData.pzhId;
+            if (_parent.pzp_state.connectedPzh[pzhId] && _parent.pzp_state.enrolled) {
+                var localServices = self.discovery.getRegisteredServices ();
+                var msg = {"type":"prop",
+                    "from"       :_parent.pzp_state.sessionId,
+                    "to"         :pzhId,
+                    "payload"    :{"status":"registerServices",
+                        "message":{services:localServices,
+                           "from":_parent.pzp_state.sessionId}}};
+                _parent.sendMessage (msg, pzhId);
+                logger.log ("sent msg to register local services with pzh");
+            }
+        }, 6000);
     };
 
     /**

--- a/webinos/core/pzp/lib/pzp_sessionHandling.js
+++ b/webinos/core/pzp/lib/pzp_sessionHandling.js
@@ -367,7 +367,7 @@ var PzpServer = function (parent) {
         logger.log("Authorised session " + clientSessionId);
 
         parent.pzp_state.connectedPzp[clientSessionId] = _conn;
-        parent.setConnectState("peer"
+        parent.setConnectState("peer", true);
         _conn.id = clientSessionId;
 
         msg = parent.webinos_manager.messageHandler.registerSender (parent.pzp_state.sessionId, clientSessionId);

--- a/webinos/core/pzp/lib/pzp_sessionHandling.js
+++ b/webinos/core/pzp/lib/pzp_sessionHandling.js
@@ -605,7 +605,6 @@ var EnrollPzp = function (_parent, hub) {
         }
         _parent.config.storeMetaData (_parent.config.metaData);
         _parent.config.storeAll ();
-
         _parent.pzp_state.enrolled = true; // Moved from Virgin mode to hub mode
 
         hub.connect (function (status) {

--- a/webinos/core/pzp/lib/pzp_sessionHandling.js
+++ b/webinos/core/pzp/lib/pzp_sessionHandling.js
@@ -34,7 +34,7 @@ var Pzp = function () {
         discoveredPzp:[], // Store Discovered PZP details
         networkAddr: "",
         connectingPeerAddr: "",
-        connectedDevicesToPzh: {pzp:[], pzh: []}}; //Stores information about device connected to PZH but not to PZP.
+        connectedDevicesToPzh: {pzp:{}, pzh: {} } }; //Stores information about device connected to PZH but not to PZP.
     self.config = {}; // All data in this structure will be persistent information, set by configuration.js
     self.webinos_manager = {}; // Hold objects of connected webinos manager
     self.pzpClient = {}; //

--- a/webinos/core/pzp/lib/pzp_sessionHandling.js
+++ b/webinos/core/pzp/lib/pzp_sessionHandling.js
@@ -87,7 +87,7 @@ var Pzp = function () {
             var connList=[],key, list = (type === "pzp") ? self.pzp_state.connectedPzp: self.pzp_state.connectedPzh;
             for (key in list) {
                 if (list.hasOwnProperty(key)) {
-                    connList.push(list[key].friendlyName || key);
+                    connList.push({friendlyName: list[key].friendlyName, key: key});
                 }
             }
             return connList;
@@ -103,7 +103,11 @@ var Pzp = function () {
             }
         }
         if (self.pzp_state.enrolled) {
-            self.sendMessage (msg, self.config.metaData.pzhId);
+            msg = self.prepMsg(self.config.metaData.pzhId, "update",
+                {friendlyName: self.config.metaData.friendlyName,
+                    connectedPzp: getConnectedList("pzp"),
+                    connectedPzh: getConnectedList("pzh")});
+            self.sendMessage(msg, self.config.metaData.pzhId);
         }
     };
 

--- a/webinos/core/pzp/lib/pzp_websocket.js
+++ b/webinos/core/pzp/lib/pzp_websocket.js
@@ -136,22 +136,24 @@ var PzpWSS = function (_parent) {
     }
 
     function setOriginalId(id) {
-        var matchId= id.split("/")[0], key;
-        if(matchId === parent.config.metaData.friendlyName) {
-            id = parent.pzp_state.sessionId +"/"+ id.split('/')[1];
-        } else {
-            for (key in parent.pzp_state.connectedPzp) {
-                if (parent.pzp_state.connectedPzp.hasOwnProperty(key) &&
-                    parent.pzp_state.connectedPzp[key].friendlyName === matchId) {
-                    id = key;
-                    break;
+        if (id) {
+            var matchId= id.split("/")[0], key;
+            if(matchId === parent.config.metaData.friendlyName) {
+                id = (id.split('/').length > 1) ? (parent.pzp_state.sessionId +"/"+ id.split('/')[1]) : parent.pzp_state.sessionId;
+            } else {
+                for (key in parent.pzp_state.connectedPzp) {
+                    if (parent.pzp_state.connectedPzp.hasOwnProperty(key) &&
+                        parent.pzp_state.connectedPzp[key].friendlyName === matchId) {
+                        id = key;
+                        break;
+                    }
                 }
-            }
-            for (key in parent.pzp_state.connectedPzh) {
-                if (parent.pzp_state.connectedPzh.hasOwnProperty(key) &&
-                    parent.pzp_state.connectedPzh[key].friendlyName === matchId) {
-                    id = key;
-                    break;
+                for (key in parent.pzp_state.connectedPzh) {
+                    if (parent.pzp_state.connectedPzh.hasOwnProperty(key) &&
+                        parent.pzp_state.connectedPzh[key].friendlyName === matchId) {
+                        id = key;
+                        break;
+                    }
                 }
             }
         }

--- a/webinos/core/pzp/lib/pzp_websocket.js
+++ b/webinos/core/pzp/lib/pzp_websocket.js
@@ -54,36 +54,24 @@ var PzpWSS = function (_parent) {
     }
 
     function getConnectedPzp() {
-        var list = [];
-        for (var key in parent.pzp_state.connectedPzp) {
+        var list = [], key;
+        for (key in parent.pzp_state.connectedPzp) {
             if(parent.pzp_state.connectedPzp.hasOwnProperty(key)) {
-                if(parent.pzp_state.connectedPzp[key].friendlyName) {
-                    list.push(parent.pzp_state.connectedPzp[key].friendlyName);
-                } else {
-                    list.push(key);
-                }
+                list.push(parent.pzp_state.connectedPzp[key].friendlyName || key);
             }
         }
         for (key = 0; key < parent.pzp_state.connectedDevicesToPzh.pzp.length; key = key + 1) {
             list.push(parent.pzp_state.connectedDevicesToPzh.pzp[key].friendlyName);
         }
-        list.push(parent.config.metaData.friendlyName + " (This Device)");
+        list.push(parent.config.metaData.friendlyName);
         return list;
     }
 
     function getConnectedPzh(){
-        var list = [];
-        for (var key in parent.pzp_state.connectedPzh) {
+        var list = [], key;
+        for (key in parent.pzp_state.connectedPzh) {
             if(parent.pzp_state.connectedPzh.hasOwnProperty(key)) {
-                if(parent.pzp_state.connectedPzh[key].friendlyName) {
-                    if(key === parent.config.metaData.pzhId) {
-                        list.push(parent.pzp_state.connectedPzh[key].friendlyName +" (Your PZH)");
-                    } else {
-                        list.push(parent.pzp_state.connectedPzh[key].friendlyName);
-                    }
-                } else {
-                    list.push(key);
-                }
+                list.push(parent.pzp_state.connectedPzh[key].friendlyName || key);
             }
         }
         for (key = 0; key < parent.pzp_state.connectedDevicesToPzh.pzh.length; key = key + 1) {

--- a/webinos/core/pzp/lib/pzp_websocket.js
+++ b/webinos/core/pzp/lib/pzp_websocket.js
@@ -137,7 +137,7 @@ var PzpWSS = function (_parent) {
 
     function setOriginalId(id) {
         if (id) {
-            var matchId= id.split("/")[0], key, i;
+            var matchId= id.split("/") && id.split("/")[0], key, i;
             if(matchId === parent.config.metaData.friendlyName) {
                 id = (id.split('/').length > 1) ? (parent.pzp_state.sessionId +"/"+ id.split('/')[1]) : parent.pzp_state.sessionId;
             } else {
@@ -195,9 +195,7 @@ var PzpWSS = function (_parent) {
         msg.to = setOriginalId(msg.to);
         msg.from = setOriginalId(msg.from);
         msg.resp_to = setOriginalId(msg.resp_to);
-        if(msg.payload && msg.payload.method && msg.payload.method.indexOf("registerPeer") > -1) {
-            msg.payload.params.peerId = setOriginalId(msg.payload.params.peerId);// As javascript is not fully pass by reference..
-        }
+
         if (msg.type === "prop") {
             switch (msg.payload.status) {
                 case "registerBrowser":

--- a/webinos/core/pzp/lib/pzp_websocket.js
+++ b/webinos/core/pzp/lib/pzp_websocket.js
@@ -62,7 +62,7 @@ var PzpWSS = function (_parent) {
         }
         for (key in parent.pzp_state.connectedDevicesToPzh.pzp) {
             if(parent.pzp_state.connectedDevicesToPzh.pzp.hasOwnProperty(key)) {
-                list.push(parent.pzp_state.connectedDevicesToPzh.pzp[key].friendlyName || key);
+                list.push(parent.pzp_state.connectedDevicesToPzh.pzp[key] || key);
             }
         }
         list.push(parent.config.metaData.friendlyName);
@@ -78,7 +78,7 @@ var PzpWSS = function (_parent) {
         }
         for (key in parent.pzp_state.connectedDevicesToPzh.pzh) {
             if(parent.pzp_state.connectedDevicesToPzh.pzh.hasOwnProperty(key)) {
-                list.push(parent.pzp_state.connectedDevicesToPzh.pzh[key].friendlyName || key);
+                list.push(parent.pzp_state.connectedDevicesToPzh.pzh[key] || key);
             }
         }
         return list;
@@ -117,7 +117,7 @@ var PzpWSS = function (_parent) {
     }
 
     function setInternalParams(id) {
-        var to, i;
+        var to;
         if(id === parent.pzp_state.sessionId) {
             id = parent.config.metaData.friendlyName; // Special case of findServices
         } else if (parent.pzp_state.connectedPzp.hasOwnProperty(id) && parent.pzp_state.connectedPzp[id].friendlyName) {
@@ -127,19 +127,10 @@ var PzpWSS = function (_parent) {
         } else if (connectedWebApp[id]) {
             to = (id.split("/") && id.split("/").length === 2) ? id.split("/")[1] : id.split("/")[2];
             id = parent.config.metaData.friendlyName + "/"+ to;
-        } else {
-            for (i = 0; i < parent.pzp_state.connectedDevicesToPzh.pzp.length; i = i + 1) {
-                if (parent.pzp_state.connectedDevicesToPzh.pzp[i].key === id)  {
-                    id = parent.pzp_state.connectedDevicesToPzh.pzp[i].friendlyName;
-                    break;
-                }
-            }
-            for (i = 0; i < parent.pzp_state.connectedDevicesToPzh.pzh.length; i = i + 1) {
-                if (parent.pzp_state.connectedDevicesToPzh.pzh[i].key === id)  {
-                    id = parent.pzp_state.connectedDevicesToPzh.pzh[i].friendlyName;
-                    break;
-                }
-            }
+        } else if(parent.pzp_state.connectedDevicesToPzh.pzp[id]) {
+            id = parent.pzp_state.connectedDevicesToPzh.pzp[id];
+        } else if(parent.pzp_state.connectedDevicesToPzh.pzh[id]) {
+            id = parent.pzp_state.connectedDevicesToPzh.pzh[id];
         }
         return id;
     }
@@ -164,15 +155,17 @@ var PzpWSS = function (_parent) {
                         break;
                     }
                 }
-                for (i = 0; i < parent.pzp_state.connectedDevicesToPzh.pzp.length; i = i + 1) {
-                    if (parent.pzp_state.connectedDevicesToPzh.pzp[i].friendlyName === matchId)  {
-                        id = parent.pzp_state.connectedDevicesToPzh.pzp[i].key;
+                for (key in parent.pzp_state.connectedDevicesToPzh.pzp) {
+                    if (parent.pzp_state.connectedDevicesToPzh.pzp.hasOwnProperty(key) &&
+                        parent.pzp_state.connectedDevicesToPzh.pzp[key] === matchId) {
+                        id = key;
                         break;
                     }
                 }
-                for (i = 0; i < parent.pzp_state.connectedDevicesToPzh.pzh.length; i = i + 1) {
-                    if (parent.pzp_state.connectedDevicesToPzh.pzh[i].friendlyName === matchId)  {
-                        id = parent.pzp_state.connectedDevicesToPzh.pzh[i].key;
+                for (key in parent.pzp_state.connectedDevicesToPzh.pzh) {
+                    if (parent.pzp_state.connectedDevicesToPzh.pzh.hasOwnProperty(key) &&
+                        parent.pzp_state.connectedDevicesToPzh.pzh[key] === matchId) {
+                        id = key;
                         break;
                     }
                 }

--- a/webinos/core/pzp/lib/pzp_websocket.js
+++ b/webinos/core/pzp/lib/pzp_websocket.js
@@ -60,8 +60,10 @@ var PzpWSS = function (_parent) {
                 list.push(parent.pzp_state.connectedPzp[key].friendlyName || key);
             }
         }
-        for (key = 0; key < parent.pzp_state.connectedDevicesToPzh.pzp.length; key = key + 1) {
-            list.push(parent.pzp_state.connectedDevicesToPzh.pzp[key].friendlyName);
+        for (key in parent.pzp_state.connectedDevicesToPzh.pzp) {
+            if(parent.pzp_state.connectedDevicesToPzh.pzp.hasOwnProperty(key)) {
+                list.push(parent.pzp_state.connectedDevicesToPzh.pzp[key].friendlyName || key);
+            }
         }
         list.push(parent.config.metaData.friendlyName);
         return list;
@@ -74,8 +76,10 @@ var PzpWSS = function (_parent) {
                 list.push(parent.pzp_state.connectedPzh[key].friendlyName || key);
             }
         }
-        for (key = 0; key < parent.pzp_state.connectedDevicesToPzh.pzh.length; key = key + 1) {
-            list.push(parent.pzp_state.connectedDevicesToPzh.pzh[key].friendlyName);
+        for (key in parent.pzp_state.connectedDevicesToPzh.pzh) {
+            if(parent.pzp_state.connectedDevicesToPzh.pzh.hasOwnProperty(key)) {
+                list.push(parent.pzp_state.connectedDevicesToPzh.pzh[key].friendlyName || key);
+            }
         }
         return list;
     }
@@ -764,12 +768,13 @@ var PzpWSS = function (_parent) {
                 }
 
                 try {
+                    var jsonString = JSON.stringify(message);
                     connectedWebApp[address].socket.pause ();
-                    connectedWebApp[address].sendUTF(message);
+                    connectedWebApp[address].sendUTF(jsonString);
                 } catch (err) {
                     self.pzp_state.logger.error ("exception in sending message to pzp - " + err);
                 } finally {
-                    logger.log ('send to web app - ' + address + ' message ' + message);
+                    logger.log ('send to web app - ' + address + ' message ' + jsonString);
                     connectedWebApp[address].socket.resume ();
                 }
             } else {

--- a/webinos/core/pzp/lib/pzp_websocket.js
+++ b/webinos/core/pzp/lib/pzp_websocket.js
@@ -202,7 +202,8 @@ var PzpWSS = function (_parent) {
                     parent.pzpWebSocket.connectedApp(connection, msg.payload.value);
                     break;
                 case "setFriendlyName":
-                    parent.changeFriendlyName (msg.payload.value);
+                    //parent.changeFriendlyName(msg.payload.value);
+                    // THis functionality will be added via webinos core api.
                     break;
                 case "getFriendlyName":
                     var msg1 = prepMsg(msg.from, "friendlyName", parent.config.metaData.friendlyName);
@@ -224,7 +225,9 @@ var PzpWSS = function (_parent) {
                     }
                     break;
                 case "signedCertByPzh":
-                    parent.enrollPzp.register (msg.from, msg.payload.message.clientCert, msg.payload.message.masterCert, msg.payload.message.masterCrl);
+                    if (expectedPzhAddress === (msg.from && msg.from.split("_") && msg.from.split("_")[0])) {
+                        parent.enrollPzp.register (msg.from, msg.payload.message.clientCert, msg.payload.message.masterCert, msg.payload.message.masterCrl);
+                    }
                     break;
                 case "setPzhProviderAddress":
                     setPzhProviderAddress (msg.payload.message);
@@ -261,11 +264,9 @@ var PzpWSS = function (_parent) {
                     });
                     break;
                 case "intraPeer":
-                {
                     connectintra(msg, function(value){
                         logger.log("connect intra-zone peer: " + value);
                     });
-                }
                     break;
             }
         } else {

--- a/webinos/core/pzp/lib/pzp_websocket.js
+++ b/webinos/core/pzp/lib/pzp_websocket.js
@@ -41,25 +41,49 @@ var PzpWSS = function (_parent) {
         }
     }
 
-    function prepMsg (from, to, status, message) {
-        "use strict";
+    function prepMsg(from, to, status, message) {
         return {
-            "type"   :"prop",
-            "from"   :from,
-            "to"     :to,
-            "payload":{
-                "status" :status,
-                "message":message
+            "type": "prop",
+            "from": from,
+            "to": to,
+            "payload": {
+                "status": status,
+                "message": message
             }
         };
     }
 
-    function getConnectedPzp () {
-        return Object.keys (parent.pzp_state.connectedPzp);
+    function getConnectedPzp() {
+        var list = [];
+        for (var key in parent.pzp_state.connectedPzp) {
+            if(parent.pzp_state.connectedPzp.hasOwnProperty(key)) {
+                if(parent.pzp_state.connectedPzp[key].friendlyName) {
+                    list.push(parent.pzp_state.connectedPzp[key].friendlyName);
+                } else {
+                    list.push(key);
+                }
+            }
+        }
+        list.push(parent.config.metaData.friendlyName + " (This Device)")
+        return list;
     }
 
-    function getConnectedPzh () {
-        return Object.keys (parent.pzp_state.connectedPzh);
+    function getConnectedPzh(){
+        var list = [];
+        for (var key in parent.pzp_state.connectedPzh) {
+            if(parent.pzp_state.connectedPzh.hasOwnProperty(key)) {
+                if(parent.pzp_state.connectedPzh[key].friendlyName) {
+                    if(key === parent.config.metaData.pzhId) {
+                        list.push(parent.pzp_state.connectedPzh[key].friendlyName +" (Your PZH)");
+                    } else {
+                        list.push(parent.pzp_state.connectedPzh[key].friendlyName);
+                    }
+                } else {
+                    list.push(key);
+                }
+            }
+        }
+        return list;
     }
 
     function getVersion (from) {
@@ -615,15 +639,6 @@ var PzpWSS = function (_parent) {
             }
         }
     }
-
-    function handleData (cmd, data) {
-        var msg = {type:"prop", from:parent.pzp_state.sessionId, to:"", payload:{ status:cmd, message:data}};
-        for (var id in connectedWebApp) {
-            msg.to = id;
-            connectedWebApp[id].sendUTF (JSON.stringify (msg));
-        }
-    }
-
 
     function approveRequest (request) {
         var requestor = request.host.split (":")[0]; // don't care about port.

--- a/webinos/core/util/lib/configuration.js
+++ b/webinos/core/util/lib/configuration.js
@@ -613,9 +613,12 @@ Config.prototype.fetchConfigDetails = function (webinosType, inputConfig, callba
                 self.userPref.ports.pzp_zeroConf = userPref.ports.pzp_zeroConf;
                 if (webinosType === "Pzh" || webinosType === "PzhCA") {
                     self.storeUserDetails(inputConfig.user);
-                    self.metaData.friendlyName = self.userData.name;
+                    self.metaData.friendlyName = self.userData.name +" ("+ self.userData.authenticator + ")";
                 } else {
                     self.userData.email = userPref.certConfiguration.email;
+                }
+                if (userPref.friendlyName && userPref.friendlyName !== "") {
+                    self.metaData.friendlyName =  userPref.friendlyName;
                 }
                 self.userData.country = userPref.certConfiguration.country;
                 self.userData.state = userPref.certConfiguration.state;

--- a/webinos/core/util/lib/configuration.js
+++ b/webinos/core/util/lib/configuration.js
@@ -572,6 +572,8 @@ Config.prototype.fetchConfigDetails = function (webinosType, inputConfig, callba
     var self = this;
     var filePath = path.resolve (__dirname, "../../../../webinos_config.json");
     wId.fetchDeviceName (webinosType, inputConfig, function (deviceName) {
+        self.metaData.webinosType = webinosType;
+        self.metaData.serverName = inputConfig.sessionIdentity;
         self.metaData.webinosName = deviceName;
         self.metaData.webinosRoot = wPath.webinosPath () + "/" + self.metaData.webinosName;
         self.createDirectories (function (status) {
@@ -590,17 +592,11 @@ Config.prototype.fetchConfigDetails = function (webinosType, inputConfig, callba
                 self.userPref.ports.pzp_webSocket = userPref.ports.pzp_webSocket;
                 self.userPref.ports.pzp_tlsServer = userPref.ports.pzp_tlsServer;
                 self.userPref.ports.pzp_zeroConf = userPref.ports.pzp_zeroConf;
-
-                if (self.userData.name === "") {
-                    self.userData.country = userPref.certConfiguration.country;
-                    self.userData.email = userPref.certConfiguration.email;
-                }
                 self.userData.state = userPref.certConfiguration.state;
                 self.userData.city = userPref.certConfiguration.city;
                 self.userData.orgName = userPref.certConfiguration.orgname;
                 self.userData.orgUnit = userPref.certConfiguration.orgunit;
                 self.userData.cn = userPref.certConfiguration.cn;
-
                 if (webinosType === "Pzh") {
                     for (key in userPref.pzhDefaultServices) {
                         self.serviceCache.push ({"name":userPref.pzhDefaultServices[key].name, "params":userPref.pzpDefaultServices[key].params});
@@ -628,9 +624,6 @@ Config.prototype.fetchConfigDetails = function (webinosType, inputConfig, callba
                 self.userData.orgUnit = "";
                 self.userData.cn = "";
             }
-            self.metaData.friendlyName = inputConfig.friendlyName;
-            self.metaData.webinosType = webinosType;
-            self.metaData.serverName = inputConfig.sessionIdentity;
             self.createPolicyFile (self);
             self.storeMetaData (self.metaData);
             self.storeUserData (self.userData);

--- a/webinos/core/util/lib/configuration.js
+++ b/webinos/core/util/lib/configuration.js
@@ -562,6 +562,24 @@ Config.prototype.createPolicyFile = function (self) {
     });
 };
 
+function setFriendlyName(self, friendlyName) {
+    if(friendlyName) {
+        self.metaData.friendlyName = friendlyName;
+    } else {
+        if (os.platform() && os.platform().toLowerCase() === "android" ){
+            self.metaData.friendlyName = "Mobile";
+        } else if (process.platform === "win32") {
+            self.metaData.friendlyName = "Windows PC";
+        } else if (process.platform === "darwin") {
+            self.metaData.friendlyName = "MacBook";
+        } else if (process.platform === "linux" || process.platform === "freebsd") {
+            self.metaData.friendlyName = "Linux Device";
+        } else {
+            self.metaData.friendlyName = "Webinos Device";// Add manually
+        }
+    }
+
+}
 /**
  *
  * @param webinosType
@@ -576,6 +594,7 @@ Config.prototype.fetchConfigDetails = function (webinosType, inputConfig, callba
         self.metaData.serverName = inputConfig.sessionIdentity;
         self.metaData.webinosName = deviceName;
         self.metaData.webinosRoot = wPath.webinosPath () + "/" + self.metaData.webinosName;
+        setFriendlyName(self, inputConfig.friendlyName);
         self.createDirectories (function (status) {
             if (status) {
                 logger.log ("created default webinos directories at location : " + self.metaData.webinosRoot);
@@ -592,6 +611,13 @@ Config.prototype.fetchConfigDetails = function (webinosType, inputConfig, callba
                 self.userPref.ports.pzp_webSocket = userPref.ports.pzp_webSocket;
                 self.userPref.ports.pzp_tlsServer = userPref.ports.pzp_tlsServer;
                 self.userPref.ports.pzp_zeroConf = userPref.ports.pzp_zeroConf;
+                if (webinosType === "Pzh" || webinosType === "PzhCA") {
+                    self.storeUserDetails(inputConfig.user);
+                    self.metaData.friendlyName = self.userData.name;
+                } else {
+                    self.userData.email = userPref.certConfiguration.email;
+                }
+                self.userData.country = userPref.certConfiguration.country;
                 self.userData.state = userPref.certConfiguration.state;
                 self.userData.city = userPref.certConfiguration.city;
                 self.userData.orgName = userPref.certConfiguration.orgname;

--- a/webinos/core/wrt/lib/webinos.app2app.js
+++ b/webinos/core/wrt/lib/webinos.app2app.js
@@ -28,12 +28,13 @@
     this.base = WebinosService;
     this.base(params);
 
-    this.peerId = webinos.messageHandler.getOwnId();
+    this.peerId = this.id;
     module = this;
 
     this.createChannel = createChannel;
     this.searchForChannels = searchForChannels;
 
+    console.log("Creating app2app instance with id "+ this.id);
     registerPeer(
       function (success) {
         console.log("Bind succeeded: registered peer.");

--- a/webinos/core/wrt/lib/webinos.js
+++ b/webinos/core/wrt/lib/webinos.js
@@ -100,11 +100,14 @@
                 webinos.messageHandler.onMessageReceived (data, data.to);
             }
         };
+        channel.onopen = function() {
+          var url = window.location.pathname;
+          var filename = url.substring(url.lastIndexOf('/')+1);
+          webinos.session.message_send({type: 'prop', payload: {status:'registerBrowser', value: filename}});
+        };
     }
 
     createCommChannel ();
-
-    if (typeof webinos === 'undefined') webinos = {};
 
     webinos.rpcHandler = new RPCHandler (undefined, new Registry ());
     webinos.messageHandler = new MessageHandler (webinos.rpcHandler);

--- a/webinos/core/wrt/lib/webinos.session.js
+++ b/webinos/core/wrt/lib/webinos.session.js
@@ -109,39 +109,6 @@
     webinos.session.isConnected = function () {
         return isConnected;
     };
-    function callListenerForMsg (data) {
-        var listeners = listenerMap[data.payload.status] || [];
-        for (var i = 0; i < listeners.length; i++) {
-            listeners[i] (data);
-        }
-    }
-
-    function setWebinosMessaging () {
-        webinos.messageHandler.setGetOwnId (sessionId);
-        var msg = webinos.messageHandler.registerSender (sessionId, pzpId);
-        webinos.session.message_send (msg, pzpId);
-    }
-
-    function setIsConnected () {
-        isConnected = (otherPzh.indexOf (pzhId) !== -1) ? true : false;
-    }
-
-
-    function updateConnected (message) {
-        otherPzh = message.connectedPzh;
-        otherPzp = message.connectedPzp;
-        setIsConnected ();
-    }
-
-    function setWebinosSession (data) {
-        sessionId = data.to;
-        pzpId = data.from;
-        if (data.payload.message) {
-            pzhId = data.payload.message.pzhId;
-            updateConnected (data.payload.message);
-        }
-        setWebinosMessaging ();
-    }
 
   webinos.session.getSessionId = function() {
     return sessionId;
@@ -195,7 +162,7 @@
   function updateConnected(message){
     otherPzh = message.connectedPzh;
     otherPzp = message.connectedPzp;
-    isConnected = (otherPzh.indexOf (pzhId) !== -1) ? true : false;
+    isConnected = !!(otherPzh.indexOf (pzhId) !== -1);
     enrolled = message.enrolled;
     mode = message.mode;
   }

--- a/webinos/core/wrt/lib/webinos.session.js
+++ b/webinos/core/wrt/lib/webinos.session.js
@@ -28,12 +28,12 @@
   webinos.session.setChannel = function(_channel) {
     channel = _channel;
   };
-    webinos.session.setPzpPort = function (port_) {
-        port = port_;
-    };
-    webinos.session.getPzpPort = function () {
-        return port;
-    };
+  webinos.session.setPzpPort = function (port_) {
+    port = port_;
+  };
+  webinos.session.getPzpPort = function () {
+    return port;
+ };
   webinos.session.message_send_messaging = function(msg, to) {
     msg.resp_to = webinos.session.getSessionId();
     channel.send(JSON.stringify(msg));

--- a/webinos/web_root/testbed/client.html
+++ b/webinos/web_root/testbed/client.html
@@ -59,11 +59,11 @@ $ (document).ready (function () {
         $ ("#enumConnectedPzp").html ("");
         var pzhText = "", pzpText = "", style = "connected";
         for (var i = 0; i < connectedPzh.length; i += 1) {
-                pzhText += "<li><a class='" + style + "'>" + connectedPzh[i] + "</a></li>";
+            pzhText += "<li><a class='" + style + "'>" + connectedPzh[i] + (connectedPzh[i] === webinos.session.getPZHId()?" (Your Hub)": "")+"</a></li>";
         }
         $ ("#enumConnectedPzh").html (pzhText);
         for (i = 0; i < connectedPzp.length; i += 1) {
-            pzpText += "<li><a class='" + style + "'>" + connectedPzp[i] + "</a></li>";
+            pzpText += "<li><a class='" + style + "'>" + connectedPzp[i] + (connectedPzp[i] === webinos.session.getPZPId()?" (This Device)": "")+ "</a></li>";
         }
         $ ("#enumConnectedPzp").html (pzpText);
         setEnrolling ();

--- a/webinos/web_root/testbed/client.html
+++ b/webinos/web_root/testbed/client.html
@@ -11,15 +11,11 @@
 <script type="text/javascript" src="js/jquery.equalHeight.js"></script>
 <script type="text/javascript" src="../webinos.js"></script>
 <script type="text/javascript">
+
 $ (document).ready (function () {
     function setPage (type, page) {
-        var port = window.location.port;
-        if (typeof port === "undefined") {
-            port = 8080;
-        }
-        var fetch = 'http://' + window.location.hostname + ':' + port + '/client/' + page;
         $.get (page, {}, function (reply) {
-            $ ('#main').html ('<article class="module width_full"><header><h3>' + type +
+            $ ('#main').html('<article class="module width_full"><header><h3>' + type +
                     '</h3></header><div class="module_content">' + reply + '</div></article><div class="spacer"></div>');
             //$('.column').equalHeight(); // Fix height
         }, "html");
@@ -31,16 +27,16 @@ $ (document).ready (function () {
     }
     function setEnrolling () {
         var pzpId = webinos.session.getPZPId();
-        if (pzpId && pzpId.indexOf ('/') === -1) {
+        if (!webinos.session.getPZHId()) {
             $ ('#enableLogin').html ("<a href='#login' id='login'> Connect to Your PZH </a>");
             $ ("#login").click (function () {
                 setPage ("Login to your PZH", "login.html");
             });
         } else {
-            if (webinos.session.isConnected ()) {
-                $ ('#enableLogin').html ("Connected to " + webinos.session.getPZHId ());
+            if (webinos.session.isConnected()) {
+                $ ('#enableLogin').html ("Connected to " + webinos.session.getPZHId());
             } else {
-                $ ('#enableLogin').html ("Enrolled to " + webinos.session.getPZHId () + "(Not Connected)");
+                $ ('#enableLogin').html ("Enrolled to " + webinos.session.getPZHId() + "(Not Connected)");
             }
         }
     }
@@ -63,18 +59,12 @@ $ (document).ready (function () {
         $ ("#enumConnectedPzp").html ("");
         var pzhText = "", pzpText = "", style = "connected";
         for (var i = 0; i < connectedPzh.length; i += 1) {
-            if (webinos.session.getPZHId () === connectedPzh[i]) {
-                pzhText += "<li><a class='" + style + "'>" + connectedPzh[i] + " (Your PZH) </a></li>";
-            }
-            else {
                 pzhText += "<li><a class='" + style + "'>" + connectedPzh[i] + "</a></li>";
-            }
         }
         $ ("#enumConnectedPzh").html (pzhText);
         for (i = 0; i < connectedPzp.length; i += 1) {
             pzpText += "<li><a class='" + style + "'>" + connectedPzp[i] + "</a></li>";
         }
-        pzpText += "<li><a class='connected'>" + webinos.session.getPZPId () + " (This DEVICE) </a></li>";
         $ ("#enumConnectedPzp").html (pzpText);
         setEnrolling ();
     }

--- a/webinos/web_root/testbed/client42.html
+++ b/webinos/web_root/testbed/client42.html
@@ -1,9 +1,9 @@
 <html>
 <head>
     <title>PZP Testbed</title>
-    <link rel="icon" href="vehicle/webinos.ico" type="image/x-icon">
+    <link rel="icon" href="vehicle/general/webinos.ico" type="image/x-icon">
     <script type="text/javascript" src="./jquery-1.8.2.min.js"></script>
-    <script type="text/javascript" src="./webinos.js"></script>
+    <script type="text/javascript" src="../webinos.js"></script>
     <script type="text/javascript" src="js/jsrender.js"></script>
     <link rel="stylesheet" type="text/css" href="css/style.css" media="screen"/>
     <script type="text/javascript">

--- a/webinos/web_root/testbed/client42.html
+++ b/webinos/web_root/testbed/client42.html
@@ -30,6 +30,7 @@
                 webinos.discovery.findServices(new ServiceType('http://webinos.org/api/test'),
                         {onFound:function (service) {
                             test[service.serviceAddress] = service;
+                            console.log(service);
                             $('#get42Services').append($('<option>' + service.serviceAddress + '</option>'));
                         }});
             });

--- a/webinos_config.json
+++ b/webinos_config.json
@@ -133,5 +133,6 @@
     "orgunit":"WP4",
     "cn"     :"",
     "email"  :"hello@webinos.org"
-  }
+  },
+  "friendlyName":""
 }


### PR DESCRIPTION
Device named are mapped to friendly name. Sets friendlyName depending on OS else you can set it via webinos_config.json friendlyName, You can also change your friendly name via PZP testbed.

In webinos.js it does not provide information about the device id, it just provides details friendlyName. All mapping is done in websocket server of PZP. 

FindServices are checked so would appreciate if all API owners can test. More than 2 devices could have same name, I could set #2 but that will not be useful in identifying which device, so it will upto user to use set friendly name interface to change it.

Jira Issue: WP-263
