### PR TITLE
Wp 536 webinos permission

### DIFF
--- a/webinos/core/api/authentication/lib/webinos.authentication.rpc.js
+++ b/webinos/core/api/authentication/lib/webinos.authentication.rpc.js
@@ -163,10 +163,12 @@
 	var PAMConfFile = ['/etc/pam.d/login', '/etc/pam.d/system-auth', '/etc/pam.conf'], PAMUsage = false;
 	var service, i, unixlib;
 	var webinos_folder, auth_folder;
+	var dependency = require ("find-dependencies") (__dirname);
+	var pzp = dependency.global.require (dependency.global.pzp.location, "lib/pzp_sessionHandling.js");
 
 	if ((os.type().toLowerCase() === 'linux' && os.platform().toLowerCase() === 'linux') || os.type().toLowerCase() === 'darwin') {
 		// linux and mac
-		webinos_folder = path.resolve(process.env.HOME + '/.webinos/');
+		//webinos_folder = path.resolve(process.env.HOME + '/.webinos/')
 		for (i = 0; i < PAMConfFile.length; i + 1) {
 			try {
 				fs.lstatSync(PAMConfFile[i]); // test if file exists
@@ -198,6 +200,7 @@
 		webinos_folder = path.resolve(process.env.appdata + '/webinos/');
 	}
 
+	webinos_folder = pzp.getWebinosPath();
 	if (webinos_folder !== undefined && webinos_folder !== null) {
 		auth_folder = path.join(webinos_folder + '/auth_api/');
 		password_file = path.join(auth_folder + password_filename);

--- a/webinos/core/manager/context_manager/lib/commonPaths.js
+++ b/webinos/core/manager/context_manager/lib/commonPaths.js
@@ -49,11 +49,12 @@ function getUserFolder(){
 		break;
 	}
 }
-
+var dependency = require ("find-dependencies") (__dirname);
+var pzp = dependency.global.require (dependency.global.pzp.location, "lib/pzp_sessionHandling.js");
 
 commonPaths = function (){
-	var userFolder = getUserFolder(); 
-	this.getUserFolder = getUserFolder;
+	var userFolder = pzp.getWebinosPath();
+	this.getUserFolder = pzp.getWebinosPath();
 	this.storage = (userFolder!==null) ? (path.resolve(userFolder + '/' + modulePackageName) + '/') : null;
 	this.local = moduleRoot;
 	this.global = webinosRoot;

--- a/webinos/core/util/lib/configuration.js
+++ b/webinos/core/util/lib/configuration.js
@@ -102,14 +102,15 @@ function createNewConfiguration (self, webinosType, inputConfig, callback) {
 Config.prototype.setConfiguration = function (webinosType, inputConfig, callback) {
     var self = this, conn_key, cn;
     wId.fetchDeviceName (webinosType, inputConfig, function (deviceName) {
-        var webinosRoot = path.join (wPath.webinosPath (), deviceName);
+        var webinos_root =  (webinosType.search("Pzh") !== -1)? wPath.webinosPath()+"Pzh" :wPath.webinosPath();
+        var webinosName = path.join (webinos_root, deviceName);
         logger.addType (deviceName); // per instance this should be only set once..
         if (typeof callback !== "function") {
             logger.error ("callback missing");
             return;
         }
 
-        self.fetchMetaData (webinosRoot, deviceName, function (status, value) {
+        self.fetchMetaData (webinosName, deviceName, function (status, value) {
             if (status && value && (value.code === "ENOENT" || value.code === "EACCES")) {//meta data does not exist
                 createNewConfiguration (self, webinosType, inputConfig, callback);
             } else { //metaData not found
@@ -510,25 +511,21 @@ Config.prototype.fetchUserPref = function (callback) {
  * @param callback
  * @return {*}
  */
-Config.prototype.createDirectories = function (callback) {
-    var self = this, dirPath, root_permission = 0777, internal_permission = 0744;
+Config.prototype.createDirectories = function (type, callback) {
+    var self = this, dirPath, root_permission = 0744, internal_permission = 0744;
+    var webinos_root =  (type.search("Pzh") !== -1)? wPath.webinosPath()+"Pzh" :wPath.webinosPath();
     try {
         //In case of node 0.6, define the fs existsSync
         if (typeof fs.existsSync === "undefined") fs.existsSync = path.existsSync;
-        if (!fs.existsSync (wPath.webinosPath ())) {//If the folder doesn't exist
-            fs.mkdirSync (wPath.webinosPath (), root_permission);//Create it
+        if (!fs.existsSync (webinos_root)) {//If the folder doesn't exist
+            fs.mkdirSync (webinos_root, root_permission);//Create it
         }
-        if (os.platform ().toLowerCase () !== "android") {//Set permissions for android
-            if (process.getuid) {
-                fs.chown (wPath.webinosPath (), process.getuid (), process.getgid ());
-                fs.chmod (wPath.webinosPath (), root_permission);
-            }
-        }
+
         if (!fs.existsSync (self.metaData.webinosRoot))//If the folder doesn't exist
             fs.mkdirSync (self.metaData.webinosRoot, internal_permission);
         // webinos root was created, we need the following 1st level dirs
-        var list = [ path.join (wPath.webinosPath (), "logs"),
-            path.join (wPath.webinosPath (), "wrt"),
+        var list = [ path.join (self.metaData.webinosRoot, "logs"),
+            path.join (webinos_root, "wrt"),
             path.join (self.metaData.webinosRoot, "certificates"),
             path.join (self.metaData.webinosRoot, "policies"),
             path.join (self.metaData.webinosRoot, "wrt"),
@@ -592,15 +589,17 @@ function setFriendlyName(self, friendlyName) {
  * @param callback
  */
 Config.prototype.fetchConfigDetails = function (webinosType, inputConfig, callback) {
-    var self = this;
+    var self = this, webinos_root;
     var filePath = path.resolve (__dirname, "../../../../webinos_config.json");
     wId.fetchDeviceName (webinosType, inputConfig, function (deviceName) {
         self.metaData.webinosType = webinosType;
         self.metaData.serverName = inputConfig.sessionIdentity;
         self.metaData.webinosName = deviceName;
-        self.metaData.webinosRoot = wPath.webinosPath () + "/" + self.metaData.webinosName;
+
+        webinos_root =  (webinosType.search("Pzh") !== -1)? wPath.webinosPath()+"Pzh" :wPath.webinosPath();
+        self.metaData.webinosRoot = webinos_root+ "/" + self.metaData.webinosName;
         setFriendlyName(self, inputConfig.friendlyName);
-        self.createDirectories (function (status) {
+        self.createDirectories (webinosType, function (status) {
             if (status) {
                 logger.log ("created default webinos directories at location : " + self.metaData.webinosRoot);
             } else {
@@ -658,12 +657,19 @@ Config.prototype.fetchConfigDetails = function (webinosType, inputConfig, callba
                 self.userData.orgUnit = "";
                 self.userData.cn = "";
             }
+<<<<<<< HEAD
             self.createPolicyFile (self);
+=======
+            self.metaData.friendlyName = inputConfig.friendlyName;
+            self.metaData.webinosType = webinosType;
+            self.metaData.serverName = inputConfig.sessionIdentity;
+>>>>>>> Separation of folder for PZH and PZP
             self.storeMetaData (self.metaData);
             self.storeUserData (self.userData);
             self.storeUserPref (self.userPref);
             self.storeServiceCache (self.serviceCache);
             self.storeUntrustedCert (self.untrustedCert);
+            self.createPolicyFile (self);
             callback (true);
         });
     });

--- a/webinos/core/util/lib/configuration.js
+++ b/webinos/core/util/lib/configuration.js
@@ -511,28 +511,33 @@ Config.prototype.fetchUserPref = function (callback) {
  * @return {*}
  */
 Config.prototype.createDirectories = function (callback) {
-    var self = this, dirPath, permission = 0777;
+    var self = this, dirPath, root_permission = 0777, internal_permission = 0744;
     try {
         //In case of node 0.6, define the fs existsSync
         if (typeof fs.existsSync === "undefined") fs.existsSync = path.existsSync;
-        if (!fs.existsSync (wPath.webinosPath ()))//If the folder doesn't exist
-            fs.mkdirSync (wPath.webinosPath (), permission);//Create it
-        //Set permissions for android
-        if (os.platform ().toLowerCase () !== "android") {
+        if (!fs.existsSync (wPath.webinosPath ())) {//If the folder doesn't exist
+            fs.mkdirSync (wPath.webinosPath (), root_permission);//Create it
+        }
+        if (os.platform ().toLowerCase () !== "android") {//Set permissions for android
             if (process.getuid) {
                 fs.chown (wPath.webinosPath (), process.getuid (), process.getgid ());
-                fs.chmod (wPath.webinosPath (), permission);
+                fs.chmod (wPath.webinosPath (), root_permission);
             }
         }
         if (!fs.existsSync (self.metaData.webinosRoot))//If the folder doesn't exist
-            fs.mkdirSync (self.metaData.webinosRoot, permission);
+            fs.mkdirSync (self.metaData.webinosRoot, internal_permission);
         // webinos root was created, we need the following 1st level dirs
-        var list = [ path.join (wPath.webinosPath (), "logs"), path.join (self.metaData.webinosRoot, "wrt"), path.join (wPath.webinosPath (), "wrt"), path.join (self.metaData.webinosRoot, "policies"),
-            path.join (self.metaData.webinosRoot, "certificates"), path.join (self.metaData.webinosRoot, "userData"), path.join (self.metaData.webinosRoot, "keys"), path.join (self.metaData.webinosRoot, "certificates", "external"),
+        var list = [ path.join (wPath.webinosPath (), "logs"),
+            path.join (wPath.webinosPath (), "wrt"),
+            path.join (self.metaData.webinosRoot, "certificates"),
+            path.join (self.metaData.webinosRoot, "policies"),
+            path.join (self.metaData.webinosRoot, "wrt"),
+            path.join (self.metaData.webinosRoot, "userData"),
+            path.join (self.metaData.webinosRoot, "keys"),
+            path.join (self.metaData.webinosRoot, "certificates", "external"),
             path.join (self.metaData.webinosRoot, "certificates", "internal")];
         list.forEach (function (name) {
-            if (!fs.existsSync (name))
-                fs.mkdirSync (name, permission);
+            if (!fs.existsSync (name)) fs.mkdirSync (name, internal_permission);
         });
         // Notify that we are done
         callback (true);

--- a/webinos/core/util/lib/configuration.js
+++ b/webinos/core/util/lib/configuration.js
@@ -657,13 +657,7 @@ Config.prototype.fetchConfigDetails = function (webinosType, inputConfig, callba
                 self.userData.orgUnit = "";
                 self.userData.cn = "";
             }
-<<<<<<< HEAD
-            self.createPolicyFile (self);
-=======
-            self.metaData.friendlyName = inputConfig.friendlyName;
-            self.metaData.webinosType = webinosType;
-            self.metaData.serverName = inputConfig.sessionIdentity;
->>>>>>> Separation of folder for PZH and PZP
+
             self.storeMetaData (self.metaData);
             self.storeUserData (self.userData);
             self.storeUserPref (self.userPref);

--- a/webinos/core/util/lib/webinosPath.js
+++ b/webinos/core/util/lib/webinosPath.js
@@ -27,20 +27,20 @@ exports.webinosPath = function() {
   var webinosDemo;
   switch(os.type().toLowerCase()){
     case "windows_nt":
-      webinosDemo = path.resolve(process.env.appdata + "/webinos/");
+      webinosDemo = path.resolve(process.env.appdata + "/webinos");
       break;
     case "linux":
       switch(os.platform().toLowerCase()){
         case "android":
-          webinosDemo = path.resolve(process.env.EXTERNAL_STORAGE + "/.webinos/");
+          webinosDemo = path.resolve("/data/data/org.webinos.app/webinos");
           break;
         case "linux":
-          webinosDemo = path.resolve(process.env.HOME + "/.webinos/");
+          webinosDemo = path.resolve(process.env.HOME + "/.webinos");
           break;
       }
       break;
     case "darwin":
-      webinosDemo = path.resolve(process.env.HOME + "/.webinos/");
+      webinosDemo = path.resolve(process.env.HOME + "/.webinos");
       break;
   }
   return webinosDemo;

--- a/webinos_config.json
+++ b/webinos_config.json
@@ -9,14 +9,6 @@
   },
   "pzhDefaultServices":[
     {
-      "name"  :"context",
-      "params":{}
-    },
-    {
-      "name"  :"events",
-      "params":{}
-    },
-    {
       "name"  :"test",
       "params":{}
     },
@@ -33,10 +25,6 @@
       "params":{
         "num":"21"
       }
-    },
-    {
-      "name"  :"zap-and-shake",
-      "params":{}
     },
     {
       "name"  :"actuator",


### PR DESCRIPTION
Separation of folder for PZH and PZP …
- Changes due to folder permission
- Directories and files are created default to mode 0644.
- Default directory of android changed to /data/data/org.webinos.app/.
- Context and authentication api have their path and will be created inside PZP directory.
- Removed zap and shake from pzp module load as it generates loading error.
- Removed context and event from PZH default services, as event is not supported any more and context is going to be reimplemented.

Jira Issue: WP-536
