### PR TITLE
Wp 778 webinos version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# since webinos_config will be modified locally with version and ports information, it is added in omitted list.
-# but if you add new service, please remember to include file
-webinos_config.json
-
 # generated webinos.js
 webinos/web_root/webinos.js
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# since webinos_config will be modified locally with version and ports information, it is added in omitted list.
+# but if you add new service, please remember to include file
+webinos_config.json
+
 # generated webinos.js
 webinos/web_root/webinos.js
 

--- a/package.json
+++ b/package.json
@@ -1,63 +1,64 @@
-{ "name" : "webinos_platform"
-, "version" : "0.6.0"
-, "description" : "Web runtime platform based on webinos specification"
-, "keywords" :
-  [ "webinos"
-  , "api"
-  ]
-, "homepage" : "http://www.webinos.org"
-, "bugs" : "http://jira.webinos.org"
-, "repository" :
-  { "type" : "git"
-  , "url" : "http://github.com/webinos/Webinos-Platform.git"
-  }
-, "dependencies" :
-  { "webinos-jsonrpc2" : "*"
-  , "schema" : "0.x.x"
-  , "sax" : "0.x.x"
-  , "seq" : "0.x.x"
-  , "xml2js" : "0.x.x"
-  , "data2xml" : "0.8.x"
-  , "crypt" : "0.0.x"
-  , "ejs" : "0.x.x"
-  , "websocket" : "1.0.2"
-  , "ansi" : "0.0.x"
-  , "mdns" : "1.x.x"
-  , "now" : "0.8.1"
-  , "node-uuid" : "1.3.x"
-  , "find-dependencies" : "~0.0.2"
-  , "inherits" : "1.0.0"
-  , "mkdirp" : "0.3.x"
-  , "connect" : "2.6.x"
-  , "optimist" : "x.x.x"
-  }
-, "devDependencies": {
+{
+  "name": "webinos_platform",
+  "version": "v0.8.0",
+  "description": "Web runtime platform based on webinos specification",
+  "keywords": [
+    "webinos",
+    "api"
+  ],
+  "homepage": "http://www.webinos.org",
+  "bugs": "http://jira.webinos.org",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/webinos/Webinos-Platform.git"
+  },
+  "dependencies": {
+    "webinos-jsonrpc2": "*",
+    "schema": "0.x.x",
+    "sax": "0.x.x",
+    "seq": "0.x.x",
+    "xml2js": "0.x.x",
+    "data2xml": "0.8.x",
+    "crypt": "0.0.x",
+    "ejs": "0.x.x",
+    "websocket": "1.0.2",
+    "ansi": "0.0.x",
+    "mdns": "1.x.x",
+    "now": "0.8.1",
+    "node-uuid": "1.3.x",
+    "find-dependencies": "~0.0.2",
+    "inherits": "1.0.0",
+    "mkdirp": "0.3.x",
+    "connect": "2.6.x",
+    "optimist": "x.x.x"
+  },
+  "devDependencies": {
     "grunt": "~0.4.x",
     "grunt-contrib-concat": "~0.1.3",
     "grunt-contrib-uglify": "~0.1.x",
     "grunt-contrib-jshint": "~0.1.x",
     "grunt-contrib-clean": "~0.4.x"
-  }
-, "optionalDependencies" :
-  { "sqlite3" : "2.1.x"
-  , "qrcode" : "0.x.x"
-  , "openid" : "0.x.x"
-  , "express" : "3.x.x"
-  , "passport" : "x.x.x"
-  , "passport-yahoo" : "x.x.x"
-  , "passport-google" : "x.x.x"
-  , "serialport2" : "0.0.5"
-  }
-, "engines" :
-  { "node" : ">= 0.6.0"
-  , "npm" : ">= 1.1.17"
-  }
-, "preferGlobal": true
-, "bin":
-  { "webinos_pzh": "webinos_pzh.js"
-  , "webinos_pzp": "webinos_pzp.js"
-  }
-, "scripts":
-  { "install": "node-gyp configure build && grunt"
+  },
+  "optionalDependencies": {
+    "sqlite3": "2.1.x",
+    "qrcode": "0.x.x",
+    "openid": "0.x.x",
+    "express": "3.x.x",
+    "passport": "x.x.x",
+    "passport-yahoo": "x.x.x",
+    "passport-google": "x.x.x",
+    "serialport2": "0.0.5"
+  },
+  "engines": {
+    "node": ">= 0.6.0",
+    "npm": ">= 1.1.17"
+  },
+  "preferGlobal": true,
+  "bin": {
+    "webinos_pzh": "webinos_pzh.js",
+    "webinos_pzp": "webinos_pzp.js"
+  },
+  "scripts": {
+    "install": "node-gyp configure build && grunt"
   }
 }

--- a/webinos/core/manager/certificate_manager/lib/certificate.js
+++ b/webinos/core/manager/certificate_manager/lib/certificate.js
@@ -20,65 +20,66 @@ var dependency = require ("find-dependencies") (__dirname);
 var keystore = dependency.global.require (dependency.global.manager.keystore.location);
 
 var Certificate = function () {
-    var logger = dependency.global.require (dependency.global.util.location, "lib/logging.js") (__filename);
+    "use strict";
+    this.cert = {internal:{master:{}, conn:{}, web:{}}, external:{}};
     keystore.call(this);
-    this.cert         = {};
-    this.cert.internal= {};
-    this.cert.external= {};
-    this.cert.internal= {master: {}, conn: {}};
+    var logger = dependency.global.require (dependency.global.util.location, "lib/logging.js") (__filename);
+    var self = this, certificateType = Object.freeze({ "SERVER": 0, "CLIENT": 1}), certificateManager;
+    try {
+        certificateManager = require ("certificate_manager");
+    } catch (err) {
+        logger.error("certificate manager is missing, please run npm install or node-gyp rebuild");
+        process.exit();
+    }
 
-    var self = this;
-
-    this.generateSelfSignedCertificate = function (type, cn, callback) {
-        var certman, obj = {}, key_id, cert_type, conn_key;
-        try {
-            certman = require ("certificate_manager");
-        } catch (err) {
-            return callback (false, err);
+    function getCertType(type) {
+        var cert_type;
+        if (type === "PzhPCA" || type === "PzhCA" || type === "PzpCA") {
+            cert_type = certificateType.SERVER;
+        } else if (type === "PzhP" || type === "Pzh" || type === "Pzp" || type === "PzhWS" || type === "PzhSSL" ) {
+            cert_type = certificateType.CLIENT;
         }
-        if (type === "PzhPCA" || type === "PzhCA") {
+        return cert_type;
+    }
+
+    function getKeyId(type) {
+        var key_id;
+        if (type === "PzhPCA" || type === "PzhCA" || type === "PzpCA") {
             key_id = self.cert.internal.master.key_id = self.metaData.webinosName + "_master";
-            cert_type = 0;
         } else if (type === "PzhP" || type === "Pzh" || type === "Pzp") {
             key_id = self.cert.internal.conn.key_id = self.metaData.webinosName + "_conn";
-            ;
-            cert_type = 1;
         } else if (type === "PzhWS") {
-            if (typeof this.cert.internal.webclient === 'undefined') {
-                this.cert.internal.webclient = {};
-            }
+            if(!self.cert.internal.webclient) {self.cert.internal.webclient = {}}
             key_id = self.cert.internal.webclient.key_id = self.metaData.webinosName + "_webclient";
-            ;
-            cert_type = 2;
-        }
-        else if (type === "PzhSSL") {
-            if (typeof this.cert.internal.webssl === 'undefined') {
-                this.cert.internal.webssl = {};
-            }
+        } else if (type === "PzhSSL") {
+            if(!self.cert.internal.webssl) {self.cert.internal.webssl = {}}
             key_id = self.cert.internal.webssl.key_id = self.metaData.webinosName + "_webssl";
-            ;
-            cert_type = 2;
         }
-        if (type === "Pzp") {
-            cert_type = 2;
-        }
+        return key_id;
+    }
+
+    this.generateSelfSignedCertificate = function (type, cn, callback) {
+        var obj = {}, key_id = getKeyId(type), cert_type = getCertType(type);
+
         if (type === "PzhCA") {
             self.cert.internal.signedCert = {};
             self.cert.internal.revokedCert = {};
+        } else if (type === "PzpCA") {
+            self.cert.internal.pzh = {}
         }
         cn = encodeURIComponent (cn);
         if (cn.length > 40) {
             cn = cn.substring (0, 40);
         }
-        self.generateKey (type, key_id, function (status, value) {
+
+        self.generateKey (type, key_id, function (status, privateKey) {
             if (!status) {
-                logger.error ("failed generating key " + value);
-                return callback (false, value);
+                logger.error ("failed generating key " + privateKey);
+                return callback (false, privateKey);
             } else {
-                logger.log ("created private key");
+                logger.log (type + " created private key (certificate generation I step)");
                 try {
-                    conn_key = value;
-                    obj.csr = certman.createCertificateRequest (value,
+                    obj.csr = certificateManager.createCertificateRequest (privateKey,
                         encodeURIComponent (self.userData.country),
                         encodeURIComponent (self.userData.state), // state
                         encodeURIComponent (self.userData.city), //city
@@ -87,66 +88,51 @@ var Certificate = function () {
                         cn,
                         encodeURIComponent (self.userData.email));
                 } catch (err) {
-                    logger.error ("failed generating csr " + err)
+                    logger.error ("failed generating csr " + err);
                     return callback (false, err);
                 }
 
                 try {
+                    logger.log (type + " generated CSR (certificate generation II step)");
                     var server = self.metaData.serverName;
                     if (require ("net").isIP (server)) {
                         server = "IP:" + self.metaData.serverName;
                     } else {
                         server = "DNS:" + self.metaData.serverName;
                     }
-                    obj.cert = certman.selfSignRequest (obj.csr, 3600, conn_key, cert_type, server);
-                    logger.log ("created self signed certificate");
+                    obj.cert = certificateManager.selfSignRequest (obj.csr, 3600, privateKey, cert_type, server);
                 } catch (e1) {
                     logger.error ("failed generating signed certificate " + e1);
                     return callback (false, e1);
                 }
                 try {
-                    obj.crl = certman.createEmptyCRL (conn_key, obj.cert, 3600, 0);
-                    logger.log ("created crl");
+                    logger.log (type + " generated self signed certificate (certificate generation III step)");
+                    obj.crl = certificateManager.createEmptyCRL (privateKey, obj.cert, 3600, 0);
                 } catch (e2) {
                     logger.error ("failed generating crl " + e2);
                     return callback (false, e2);
                 }
 
-                if (type === "PzhPCA" || type === "PzhCA") {
+                logger.log (type + " generated crl (certificate generation IV step)");
+                if (type === "PzhPCA" || type === "PzhCA" || type === "PzpCA") {
                     self.cert.internal.master.cert = obj.cert;
-                    self.crl = obj.crl;
-
-                    self.generateSignedCertificate (self.cert.internal.conn.csr, 1, function (status, value) {
-                        if (status) {
-                            self.cert.internal.conn.cert = value;
-                            return callback (true, conn_key);
-                        } else {
-                            return callback (status, value);
-                        }
-                    });
+                    self.crl.value = obj.crl;
+                    if (type === "PzpCA") { self.cert.internal.master.csr = obj.csr;} // We need to get it signed by PZH later
+                    return callback(true);
                 } else if (type === "PzhP" || type === "Pzh" || type === "Pzp") {
                     self.cert.internal.conn.cert = obj.cert;
-                    self.cert.internal.conn.csr = obj.csr;
-                    if (type === "Pzp") {
-                        self.crl = obj.crl;
-                    }
-                    return callback (true, conn_key);
-                } else if (type === "PzhWS" || type === "PzhSSL") {
-                    return callback (true, obj.csr, conn_key);
+                    if (type === "Pzp") { self.cert.internal.conn.csr = obj.csr; }
+                    return callback (true, obj.csr);
+                }  else if (type === "PzhWS" || type === "PzhSSL") {
+                    return callback (true, obj.csr);
                 }
             }
         });
     };
 
-    Certificate.prototype.getKeyHash = function(path, callback){
-        var certman, self = this;
+    this.getKeyHash = function(path, callback){
         try {
-            certman = require("certificate_manager");
-        }catch (err) {
-            return callback(false, err);
-        }
-        try{
-            var hash = certman.getHash(path);
+            var hash = certificateManager.getHash(path);
             logger.log("Key Hash is" + hash);
             return callback(true, hash);
         } catch (err) {
@@ -155,46 +141,35 @@ var Certificate = function () {
         }
     };
 
-    Certificate.prototype.generateSignedCertificate = function(csr, cert_type,  callback) {
-        var certman, self = this;
+    this.generateSignedCertificate = function (csr, callback) {
         try {
-            certman = require("certificate_manager");
-        } catch (err) {
-            return callback(false, err);
-        }
-
-        try {
-            self.fetchKey (self.cert.internal.master.key_id, function (status, value) {
+            self.fetchKey (self.cert.internal.master.key_id, function (status, privateKey) {
                 if (status) {
-                    var server;
+                    var server,  clientCert;
                     if (require ("net").isIP (self.metaData.serverName)) {
                         server = "IP:" + self.metaData.serverName;
                     } else {
                         server = "DNS:" + self.metaData.serverName;
                     }
-                    var clientCert = certman.signRequest (csr, 3600, value, self.cert.internal.master.cert, cert_type, server);
+                    clientCert = certificateManager.signRequest (csr, 3600, privateKey, self.cert.internal.master.cert, certificateType.CLIENT, server);
+                    logger.log ("signed certificate by the PZP/PZH");
                     return callback (true, clientCert);
                 } else {
-                    return callback (false, value);
+                    return callback (false, privateKey); // It is not privateKey but just variable name
                 }
             });
         } catch (err1) {
             return callback (false, err1);
         }
     };
-    Certificate.prototype.revokeClientCert = function (pzpCert, callback) {
-        "use strict";
-        var certman, self = this;
-        try {
-            certman = require ("certificate_manager");
-        } catch (err) {
-            return callback (false, err);
-        }
+
+    this.revokeClientCert = function (pzpCert, callback) {
         try {
             self.fetchKey (self.cert.internal.master.key_id, function (status, value) {
                 if (status) {
-                    var crl = certman.addToCRL ("" + value, "" + self.crl, "" + pzpCert);
+                    var crl = certificateManager.addToCRL ("" + value, "" + self.crl, "" + pzpCert);
                     // master.key.value, master.cert.value
+                    logger.log("revoked certificate");
                     return callback (true, crl);
                 } else {
                     return callback (status, value)

--- a/webinos/core/manager/certificate_manager/src/openssl_wrapper.cpp
+++ b/webinos/core/manager/certificate_manager/src/openssl_wrapper.cpp
@@ -462,7 +462,7 @@ int signRequest(char* pemRequest, int days, char* pemCAKey, char* pemCaCert,  in
   // If there is a small clock difference between machines, it results in cert_not_yet_valid
   // It does set GMT time but is relevant to machine time.
   // A better solution would be to have ntp server contacted to get a proper time.
-  if(certType == 2) {
+  if(certType == 1) {
     X509_gmtime_adj(s, long(0-300));
   }
   else {
@@ -529,18 +529,6 @@ int signRequest(char* pemRequest, int days, char* pemCAKey, char* pemCaCert,  in
     }
 
     if(!(ex = X509V3_EXT_conf_nid(NULL,  &ctx, NID_ext_key_usage, (char*)"critical, clientAuth, serverAuth"))) {
-      return ERR_peek_error();
-    } else {
-      X509_add_ext(cert, ex, -1);
-    }
-  } else if( certType == 2) {
-    if(!(ex = X509V3_EXT_conf_nid(NULL, &ctx, NID_basic_constraints, (char*)"critical, CA:FALSE"))) {
-      return ERR_peek_error();
-    } else {
-      X509_add_ext(cert, ex, -1);
-    }
-
-    if(!(ex = X509V3_EXT_conf_nid(NULL, &ctx, NID_ext_key_usage, (char*)"critical, clientAuth, serverAuth"))) {
       return ERR_peek_error();
     } else {
       X509_add_ext(cert, ex, -1);

--- a/webinos/core/manager/context_manager/lib/storageCheck.js
+++ b/webinos/core/manager/context_manager/lib/storageCheck.js
@@ -52,7 +52,6 @@ module.exports = function(myCommonPaths, myStorageInfo){
 	try{
 		fs.statSync(commonPaths.storage);
 	}catch(e){
-		debugger;
 		mkdirSyncRecursive(commonPaths.storage);
 	}
 	fixFolder(commonPaths.storage, storageInfo.Map);

--- a/webinos/core/pzh/lib/pzh_otherManager.js
+++ b/webinos/core/pzh/lib/pzh_otherManager.js
@@ -177,11 +177,11 @@ var Pzh_RPC = function (_parent) {
         if (Object.keys (result).length >= 1) {
             if (result["trustedList"]) {
                 _parent.config.metaData.trustedList = result["trustedList"];
-                _parent.config.storeTrustedList (_parent.config.metaData.trustedList);
+                _parent.config.storeDetails(null, "trustedList",_parent.config.metaData.trustedList);
             }
             if (result["crl"]) {
-                _parent.config.crl = receivedMsg[msg];
-                _parent.config.storeCrl (_parent.config.crl);
+                _parent.config.crl.value = receivedMsg[msg];
+                _parent.config.storeDetails(null, "crl", _parent.config.crl);
             }
             if (result["cert"]) {
                 //_parent.config.cert.external = receivedMsg[msg];

--- a/webinos/core/pzh/lib/pzh_provider.js
+++ b/webinos/core/pzh/lib/pzh_provider.js
@@ -100,8 +100,7 @@ var Provider = function (_hostname, _friendlyName) {
             } else {
                 setParam(function (status, options) {
                     if (status) {
-                        var tls = require("tls");
-                        server = tls.createServer(options, function (conn) {   // This is the main TLS server, pzh started are stored as SNIContext to this server
+                        server = require("tls").createServer(options, function (conn) {   // This is the main TLS server, pzh started are stored as SNIContext to this server
                             handleConnection(conn);
                         });
                         server.on("error", function (error) {
@@ -133,7 +132,7 @@ var Provider = function (_hostname, _friendlyName) {
     function addPzhDetails(uri, options) {
         server.addContext(uri, options);
         config.trustedList.pzh[uri] = {"address":hostname};
-        config.storeTrustedList(config.trustedList);
+        config.storeDetails(null, "trustedList", config.trustedList);
     }
 
     function getAllPzhList(userId, userObj) {

--- a/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
+++ b/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
@@ -441,24 +441,24 @@ var AddPzp = function (parent) {
             }
             parent.pzh_state.expecting.isExpectedCode (_msgRcvd.message.code, function (expected) { // Check QRCode if it is valid ..
                 if (expected) {
-                    _parent.config.generateSignedCertificate (_msgRcvd.message.csr, function (status, value) { // Sign certificate based on received csr from client.// pzp = 2
+                    parent.config.generateSignedCertificate (_msgRcvd.message.csr, function (status, value) { // Sign certificate based on received csr from client.// pzp = 2
                         if (status) { // unset expected QRCode
-                            _parent.config.cert.internal.signedCert[pzpId] = value;
-                            _parent.pzh_state.expecting.unsetExpected (function () {
-                                _parent.config.storeDetails(require("path").join("certificates", "internal"),null, _parent.config.cert.internal);
-                                if (!_parent.config.trustedList.pzp.hasOwnProperty (pzpId)) {// update configuration with signed certificate details ..
-                                    _parent.config.trustedList.pzp[pzpId] = {addr:"", port:""};
-                                    _parent.config.storeDetails(null, "trustedList", _parent.config.trustedList);
+                            parent.config.cert.internal.signedCert[pzpId] = value;
+                            parent.pzh_state.expecting.unsetExpected (function () {
+                                parent.config.storeDetails(require("path").join("certificates", "internal"),null, parent.config.cert.internal);
+                                if (!parent.config.trustedList.pzp.hasOwnProperty (pzpId)) {// update configuration with signed certificate details ..
+                                    parent.config.trustedList.pzp[pzpId] = {addr:"", port:""};
+                                    parent.config.storeDetails(null, "trustedList", parent.config.trustedList);
                                 }
                                 // Add PZP in list of master certificates as PZP will sign connection certificate at its end.
-                                _parent.setConnParam(function(status, options){
+                                parent.setConnParam(function(status, options){
                                     if (status) {
-                                        refreshCert(_parent.pzh_state.sessionId, options);
+                                        refreshCert(parent.pzh_state.sessionId, options);
                                         // Send signed certificate and master certificate to PZP
-                                        var payload = {"clientCert":_parent.config.cert.internal.signedCert[pzpId],
-                                                    "masterCert":_parent.config.cert.internal.master.cert,
-                                                    "masterCrl" :_parent.config.crl.value};
-                                        msg = _parent.prepMsg (_parent.config.metaData.serverName, pzpId,
+                                        var payload = {"clientCert":parent.config.cert.internal.signedCert[pzpId],
+                                                    "masterCert":parent.config.cert.internal.master.cert,
+                                                    "masterCrl" :parent.config.crl.value};
+                                        msg = parent.prepMsg (parent.config.metaData.serverName, pzpId,
                                             "signedCertByPzh", payload);
                                         _callback (true, msg);
                                     }

--- a/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
+++ b/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
@@ -458,8 +458,7 @@ var AddPzp = function (parent) {
                                         var payload = {"clientCert":parent.config.cert.internal.signedCert[pzpId],
                                                     "masterCert":parent.config.cert.internal.master.cert,
                                                     "masterCrl" :parent.config.crl.value};
-                                        msg = parent.prepMsg (parent.config.metaData.serverName, pzpId,
-                                            "signedCertByPzh", payload);
+                                        msg = parent.prepMsg (pzpId,"signedCertByPzh", payload);
                                         _callback (true, msg);
                                     }
                                 });

--- a/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
+++ b/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
@@ -320,11 +320,6 @@ var Pzh = function () {
             self.config = new util.webinosConfiguration ();
             self.config.setConfiguration ("Pzh", inputConfig, function (status, value) {
                 if (status) {
-                    if (_user && self.config.userData.name !== _user.displayName) {
-                        self.config.userData = {name : _user.displayName, email: _user.emails, country: _user.country,
-                            image: _user.image, authenticator: _user.from, identifier: _user.identifier};
-                        self.config.storeDetails("userData", null, self.config.userData);
-                    }
                     self.pzh_state.sessionId = _uri;
                     self.pzh_state.logger.addId (self.config.userData.email[0].value);
                     self.pzh_otherManager = new pzh_otherManager (self);

--- a/webinos/core/pzhweb/startweb.js
+++ b/webinos/core/pzhweb/startweb.js
@@ -74,10 +74,10 @@ function loadWSCertificate(config, certName, certLabel, callback) {
         var cn = certLabel + ":" + config.metaData.serverName;
         config.generateSelfSignedCertificate(certLabel, cn, function (status, value) {
             if (status) {
-                config.generateSignedCertificate(value, 2, function (status, value) {
+                config.generateSignedCertificate(value, function (status, value) {
                     if (status) {
                         config.cert.internal[certName].cert = value;
-                        config.storeCertificate(config.cert.internal, "internal");
+                        config.storeDetails(require("path").join("certificates", "internal"), null, config.cert.internal);
                         return callback(status);
                     } else {
                         return callback(false);
@@ -105,7 +105,6 @@ starter.start = function(hostname, friendlyName) {
                 logger.error("setting configuration for the zone provider failed, the .webinos directory needs to be deleted.")
             } else {
                 starter.startWS(hostname, config, function (err, val) {
-                    //meh.
                 });
             }
         });

--- a/webinos/core/pzp/lib/pzp_otherManager.js
+++ b/webinos/core/pzp/lib/pzp_otherManager.js
@@ -151,7 +151,7 @@ var Pzp_OtherManager = function (_parent) {
             _parent.pzp_state.connectedPzh[validMsgObj.from].friendlyName = validMsgObj.payload.message.friendlyName;
             if (_parent.config.metaData.friendlyName.indexOf(validMsgObj.payload.message.friendlyName) === -1) {
                 _parent.config.metaData.friendlyName = validMsgObj.payload.message.friendlyName + "'s " + _parent.config.metaData.friendlyName;
-                _parent.config.storeMetaData(_parent.config.metaData);
+                _parent.config.storeDetails(null, null, _parent.config.metaData);
             }
         } else if (_parent.pzp_state.connectedPzp[validMsgObj.from]) {
             _parent.pzp_state.connectedPzp[validMsgObj.from].friendlyName = validMsgObj.payload.message.friendlyName;

--- a/webinos/core/pzp/lib/pzp_otherManager.js
+++ b/webinos/core/pzp/lib/pzp_otherManager.js
@@ -78,15 +78,15 @@ var Pzp_OtherManager = function (_parent) {
         for (msg in receivedMsg) {
             if (msg === "trustedList") {
                 _parent.config.metaData.trustedList = receivedMsg[msg];
-                _parent.config.storeTrustedList (_parent.config.metaData.trustedList);
+                _parent.config.storeDetails(null, "trustedList", _parent.config.trustedList);
             }
             else if (msg === "crl") {
                 _parent.config.crl = receivedMsg[msg];
-                _parent.config.storeCrl (_parent.config.crl);
+                _parent.config.storeDetails(null, "crl", _parent.config.crl);
             }
             else if (msg === "cert") {
                 _parent.config.cert.external = receivedMsg[msg];
-                _parent.config.storeCertificate (_parent.config.cert.external, "external");
+                _parent.config.storeDetails(require("path").join("certificates", "external"), null, _parent.config.cert.external);
             }
         }
         logger.log ("Files Synchronised with the PZH");
@@ -109,14 +109,14 @@ var Pzp_OtherManager = function (_parent) {
                 if (remove) {
                     _parent.config.serviceCache.splice (i, 1);
                 }
-                _parent.config.storeServiceCache (_parent.config.serviceCache);
+                _parent.config.storeDetails("userData", "serviceCache",_parent.config.serviceCache);
                 return;
             }
         }
 
         if (!remove) {
             _parent.config.serviceCache.splice (i, 0, {"name":name, "params":{}});
-            _parent.config.storeServiceCache (_parent.config.serviceCache);
+            _parent.config.storeDetails("userData", "serviceCache",_parent.config.serviceCache);
         }
     }
 

--- a/webinos/core/pzp/lib/pzp_sessionHandling.js
+++ b/webinos/core/pzp/lib/pzp_sessionHandling.js
@@ -640,28 +640,28 @@ var EnrollPzp = function (parent, hub) {
         logger.log ("PZP ENROLLED AT  " + _from);    // This message come from PZH web server over websocket
         //_parent.config.cert.internal.conn.cert = _clientCert;
         //_parent.config.cert.internal.master.cert = _masterCert;
-        _parent.config.cert.internal.master.cert = _clientCert;
-        _parent.config.cert.internal.pzh.cert    = _masterCert;
+        parent.config.cert.internal.master.cert = _clientCert;
+        parent.config.cert.internal.pzh.cert    = _masterCert;
 
-        _parent.config.generateSignedCertificate(_parent.config.cert.internal.conn.csr, function(status, signedCert) {
+        parent.config.generateSignedCertificate(parent.config.cert.internal.conn.csr, function(status, signedCert) {
             if(status) {
                 logger.log("connection signed certificate by PZP");
-                _parent.config.cert.internal.conn.cert = signedCert;
-                _parent.config.crl.value = _masterCrl;
-                _parent.config.metaData.pzhId = _from;
-                _parent.config.metaData.serverName = _from && _from.split ("_")[0];
+                parent.config.cert.internal.conn.cert = signedCert;
+                parent.config.crl.value = _masterCrl;
+                parent.config.metaData.pzhId = _from;
+                parent.config.metaData.serverName = _from && _from.split ("_")[0];
                 if (_from.indexOf (":") !== -1) {
-                    _parent.config.metaData.serverName = _parent.config.metaData.serverName.split (":")[0];
+                    parent.config.metaData.serverName = parent.config.metaData.serverName.split (":")[0];
                 }
 
-                if (!_parent.config.trustedList.pzh.hasOwnProperty (_parent.config.metaData.pzhId)) {
-                    _parent.config.trustedList.pzh[_parent.config.metaData.pzhId] = {"addr":"", "port":""};
+                if (!parent.config.trustedList.pzh.hasOwnProperty (parent.config.metaData.pzhId)) {
+                    parent.config.trustedList.pzh[parent.config.metaData.pzhId] = {"addr":"", "port":""};
                 }
-                _parent.config.storeDetails(null, null, _parent.config.metaData);
-                _parent.config.storeDetails(null, "crl", _parent.config.crl);
-                _parent.config.storeDetails(null, "trustedList", _parent.config.trustedList);
-                _parent.config.storeDetails(require("path").join("certificates", "internal"), null, _parent.config.cert.internal);
-                _parent.pzp_state.enrolled = true; // Moved from Virgin mode to hub mode
+                parent.config.storeDetails(null, null, parent.config.metaData);
+                parent.config.storeDetails(null, "crl", parent.config.crl);
+                parent.config.storeDetails(null, "trustedList", parent.config.trustedList);
+                parent.config.storeDetails(require("path").join("certificates", "internal"), null, parent.config.cert.internal);
+                parent.pzp_state.enrolled = true; // Moved from Virgin mode to hub mode
 
 
                 hub.connect (function (status) {

--- a/webinos/core/pzp/lib/pzp_sessionHandling.js
+++ b/webinos/core/pzp/lib/pzp_sessionHandling.js
@@ -106,7 +106,7 @@ var Pzp = function () {
 
     this.changeFriendlyName = function (name) {
         self.config.metaData.friendlyName = name;
-        self.config.storeMetaData (self.config.metaData);
+        self.config.storeDetails(null, null, self.config.metaData);
         self.sendUpdateToAll();
     };
 
@@ -127,12 +127,12 @@ var Pzp = function () {
      */
     this.setConnParam = function (callback) {
         var options;
-        self.config.fetchKey (self.config.cert.internal.conn.key_id, function (status, value) {
+        self.config.fetchKey(self.config.cert.internal.conn.key_id, function (status, value) {
             if (status) {
                 if (self.pzp_state.enrolled) { // enrolled to Hub 
                     var caList = [], crlList = [], key;
-                    caList.push(self.config.cert.internal.master.cert);
-                    crlList.push(self.config.crl );
+                    caList.push(self.config.cert.internal.pzh.cert);
+                    crlList.push(self.config.crl.value );
 
                     for ( key in self.config.cert.external) {
                         if(self.config.cert.external.hasOwnProperty(key)) {
@@ -154,6 +154,7 @@ var Pzp = function () {
                     options = {
                         key               :value,
                         cert              :self.config.cert.internal.conn.cert,
+                        ca                 :self.config.cert.internal.master.cert,
                         servername        :self.config.metaData.serverName,
                         rejectUnauthorized:true,
                         requestCert       :true
@@ -310,34 +311,38 @@ var Pzp = function () {
                         self.enrollPzp = new EnrollPzp (self, hub);
                         self.pzpWebSocket = new PzpWebSocket (self);
 
-                        self.pzpWebSocket.startWebSocketServer (function (status, value) {
-                            if (status) {
-                                self.webinos_manager.initializeRPC_Message (); // Initializes RPC
-                                logger.log ("successfully started pzp websocket server ");
-                                if (self.pzp_state.enrolled) {
-                                    hub.connect (function (status, value) {  // connects hub
-                                        if (status) {
-                                            logger.log (value);
-                                        } else {
-                                            logger.error ("connection to PZH failed ");
-                                        }
-                                    });
-                                } else {
-                                    self.webinos_manager.setupMessage_RPCHandler ();
-                                }
-                                return callback (true, self.pzp_state.sessionId, self.config.cert.internal.conn.csr);// retruning csr to make test work
-                            } else {
-                                return callback (false, value);
-                            }
-                        });
+                        self.startWSS(callback);
                     }
                 });
             });
         } catch (err) {
-            self.state = self.states[0];//disconnected
+            //self.state = self.states[0];//disconnected
             return callback (false, err);
         }
     };
+
+    this.startWSS = function(callback) {
+        self.pzpWebSocket.startWebSocketServer (function (status, value) {
+            if (status) {
+                self.webinos_manager.initializeRPC_Message (); // Initializes RPC
+                logger.log ("successfully started pzp websocket server ");
+                if (self.pzp_state.enrolled) {
+                    hub.connect (function (status, value) {  // connects hub
+                        if (status) {
+                            logger.log (value);
+                        } else {
+                            logger.error ("connection to PZH failed ");
+                        }
+                    });
+                } else {
+                    self.webinos_manager.setupMessage_RPCHandler ();
+                }
+                return callback (true, self.pzp_state.sessionId, self.config.cert.internal.conn.csr);// retruning csr to make test work
+            } else {
+                return callback (false, value);
+            }
+        });
+    }
 };
 
 /**
@@ -586,6 +591,7 @@ var ConnectHub = function (parent) {
         var pzpClient, master, options = {};
         var tls = require ("tls");
         try {
+
             parent.setConnParam (function (options) {
                 pzpClient = tls.connect (parent.config.userPref.ports.provider, parent.config.metaData.serverName, options, function (conn) {
                     handleAuthorization (pzpClient, _callback);
@@ -632,27 +638,39 @@ var EnrollPzp = function (parent, hub) {
     var logger = util.webinosLogging (__filename + "_EnrollPzp") || console;
     this.register = function (_from, _clientCert, _masterCert, _masterCrl) {
         logger.log ("PZP ENROLLED AT  " + _from);    // This message come from PZH web server over websocket
-        parent.config.cert.internal.conn.cert = _clientCert;
-        parent.config.cert.internal.master.cert = _masterCert;
-        parent.config.crl = _masterCrl;
-        parent.config.metaData.pzhId = _from;
-        parent.config.metaData.serverName = _from && _from.split ("_")[0];
-        if (_from.indexOf (":") !== -1) {
-            parent.config.metaData.serverName = parent.config.metaData.serverName.split (":")[0];
-        }
+        //_parent.config.cert.internal.conn.cert = _clientCert;
+        //_parent.config.cert.internal.master.cert = _masterCert;
+        _parent.config.cert.internal.master.cert = _clientCert;
+        _parent.config.cert.internal.pzh.cert    = _masterCert;
 
-        if (!parent.config.trustedList.pzh.hasOwnProperty (parent.config.metaData.pzhId)) {
-            parent.config.trustedList.pzh[parent.config.metaData.pzhId] = {"addr":"", "port":""};
-        }
-        parent.config.storeMetaData (parent.config.metaData);
-        parent.config.storeAll ();
-        parent.pzp_state.enrolled = true; // Moved from Virgin mode to hub mode
+        _parent.config.generateSignedCertificate(_parent.config.cert.internal.conn.csr, function(status, signedCert) {
+            if(status) {
+                logger.log("connection signed certificate by PZP");
+                _parent.config.cert.internal.conn.cert = signedCert;
+                _parent.config.crl.value = _masterCrl;
+                _parent.config.metaData.pzhId = _from;
+                _parent.config.metaData.serverName = _from && _from.split ("_")[0];
+                if (_from.indexOf (":") !== -1) {
+                    _parent.config.metaData.serverName = _parent.config.metaData.serverName.split (":")[0];
+                }
 
-        hub.connect (function (status) {
-            if (status) {
-                logger.log ("successfully connected to the PZH ")
-            } else {
-                logger.error ("connection to the PZH unsuccessful")
+                if (!_parent.config.trustedList.pzh.hasOwnProperty (_parent.config.metaData.pzhId)) {
+                    _parent.config.trustedList.pzh[_parent.config.metaData.pzhId] = {"addr":"", "port":""};
+                }
+                _parent.config.storeDetails(null, null, _parent.config.metaData);
+                _parent.config.storeDetails(null, "crl", _parent.config.crl);
+                _parent.config.storeDetails(null, "trustedList", _parent.config.trustedList);
+                _parent.config.storeDetails(require("path").join("certificates", "internal"), null, _parent.config.cert.internal);
+                _parent.pzp_state.enrolled = true; // Moved from Virgin mode to hub mode
+
+
+                hub.connect (function (status) {
+                    if (status) {
+                        logger.log ("successfully connected to the PZH ")
+                    } else {
+                        logger.error ("connection to the PZH unsuccessful")
+                    }
+                });
             }
         });
     };
@@ -664,8 +682,10 @@ exports.initializePzp = function (config, callback) {
     pzpInstance.initializePzp (config, function (status, result) {
         if (status) {
             logger.log ("initialized pzp");
-        } 
-        callback(status,result);
+            callback (true);
+        } else {
+            callback (false);
+        }
     });
 };
 
@@ -681,3 +701,4 @@ exports.getWebinosPath = function () {
 exports.getWebinosPorts = function () {
     return pzpInstance.config.userPref.ports.pzp_webSocket
 };
+

--- a/webinos/core/pzp/lib/pzp_websocket.js
+++ b/webinos/core/pzp/lib/pzp_websocket.js
@@ -18,7 +18,7 @@
  *         Ziran Sun (ziran.sun@samsung.com)
  *******************************************************************************/
 
-var PzpWSS = function (_parent) {
+var PzpWSS = function (parent) {
     "use strict";
     var dependency = require ("find-dependencies") (__dirname);
     var util = dependency.global.require (dependency.global.util.location);
@@ -83,23 +83,14 @@ var PzpWSS = function (_parent) {
     }
 
     function getVersion (from) {
-        function sendVersion (data) {
-            var msg = prepMsg (from, "webinosVersion", data);
-            self.sendConnectedApp (from, msg);
-        }
-        var os = require ("os");
-        var child_process = require ("child_process").exec;
-        if (os.platform ().toLowerCase () !== "android") {
-            child_process ("git describe", function (error, stderr, stdout) {
-                if (!error) {
-                    sendVersion (stderr);
-                } else {
-                    sendVersion ("v0.7"); // Change this or find another way of reading git describe for android
-                }
-            })
+        var msg;
+        if (parent.config.metaData.webinos_version) {
+            msg = prepMsg (parent.pzp_state.sessionId, from, "webinosVersion", parent.config.metaData.webinos_version);
         } else {
-            sendVersion ("v0.7");
+            var packageValue = require("../../../../package.json")
+            msg = prepMsg (parent.pzp_state.sessionId, from, "webinosVersion", packageValue.version);
         }
+        self.sendConnectedApp (from, msg);
     }
 
     function getWebinosLog (type, from) {

--- a/webinos/core/pzp/lib/pzp_websocket.js
+++ b/webinos/core/pzp/lib/pzp_websocket.js
@@ -85,10 +85,10 @@ var PzpWSS = function (parent) {
     function getVersion (from) {
         var msg;
         if (parent.config.metaData.webinos_version) {
-            msg = prepMsg (parent.pzp_state.sessionId, from, "webinosVersion", parent.config.metaData.webinos_version);
+            msg = prepMsg (from, "webinosVersion", parent.config.metaData.webinos_version);
         } else {
             var packageValue = require("../../../../package.json")
-            msg = prepMsg (parent.pzp_state.sessionId, from, "webinosVersion", packageValue.version);
+            msg = prepMsg (from, "webinosVersion", packageValue.version);
         }
         self.sendConnectedApp (from, msg);
     }
@@ -226,7 +226,7 @@ var PzpWSS = function (parent) {
                     break;
                 case "showHashQR":
                     getHashQR(function(value){
-                        var msg5 = prepMsg(parent.pzp_state.sessionId, msg.from, "showHashQR", value);
+                        var msg5 = prepMsg(msg.from, "showHashQR", value);
                         sendtoClient(msg5);
                     });
                     break;
@@ -235,7 +235,7 @@ var PzpWSS = function (parent) {
                     var hash = msg.payload.message.hash;
                     logger.log("hash passed from client page is: " + hash);
                     checkHashQR(hash, function(value){
-                        var msg6 = prepMsg(parent.pzp_state.sessionId, msg.from, "checkHashQR", value);
+                        var msg6 = prepMsg(msg.from, "checkHashQR", value);
                         sendtoClient(msg6);
                     });
                     break;

--- a/webinos/core/util/lib/configuration.js
+++ b/webinos/core/util/lib/configuration.js
@@ -128,10 +128,6 @@ function Config () {
             self.userPref.ports = config.ports;
             self.storeDetails("userData", "userPref", self.userPref);
         }
-        if (!compareObjects(config.certConfiguration, self.userData)) {
-            self.userData = config.certConfiguration;
-            self.storeDetails("userData", null, self.userData);
-        }
         if (webinosType === "Pzh" && config.pzhDefaultServices.length !== self.serviceCache.length) {
             self.serviceCache = config.pzhDefaultServices;
             self.storeDetails("userData", "serviceCache", self.serviceCache);
@@ -233,6 +229,13 @@ function Config () {
             return callback (false, err.code);
         }
     }
+    function storeUserData(user){
+        self.userData.name = user.displayName;
+        self.userData.email = user.emails;
+        self.userData.authenticator = user.from;
+        self.userData.identifier = user.identifier;
+
+    }
     /**
      *
      * @param webinosType
@@ -247,7 +250,6 @@ function Config () {
             self.metaData.webinosName = deviceName;
             webinos_root =  (webinosType.search("Pzh") !== -1)? wPath.webinosPath()+"Pzh" :wPath.webinosPath();
             self.metaData.webinosRoot = webinos_root+ "/" + self.metaData.webinosName;
-
             setFriendlyName(inputConfig.friendlyName);
 
             createDefaultDirectories(webinosType, function (status) {
@@ -257,10 +259,11 @@ function Config () {
                     self.metaData.webinos_version = defaultConfig.webinos_version;
                     self.userPref.ports = defaultConfig.ports;
                     self.userData = defaultConfig.certConfiguration;
+                    if(inputConfig.user)  storeUserData(inputConfig.user);
                     if (webinosType === "Pzh" || webinosType === "PzhCA") {
                         self.serviceCache = defaultConfig.pzhDefaultServices.slice(0);
                         self.metaData.friendlyName = self.userData.name +" ("+ self.userData.authenticator + ")";
-                    } else if (webinosType === "Pzp") {
+                    } else if (webinosType === "Pzp" || webinosType === "PzpCA") {
                         self.serviceCache = defaultConfig.pzpDefaultServices.slice(0);
                     }
                     if (defaultConfig.friendlyName && defaultConfig.friendlyName !== "") {

--- a/webinos/core/util/lib/configuration.js
+++ b/webinos/core/util/lib/configuration.js
@@ -23,9 +23,8 @@ var os = require ("os");
 var util = require ("util");
 
 var dependency = require ("find-dependencies") (__dirname);
-var logger = dependency.global.require (dependency.global.util.location, "lib/logging.js") (__filename) || console;
-var wPath = dependency.global.require (dependency.global.util.location, "lib/webinosPath.js");
-var wId = dependency.global.require (dependency.global.util.location, "lib/webinosId.js")
+var logger = require("./logging.js") (__filename) || console;
+var wPath = require("./webinosPath.js");
 var certificate = dependency.global.require (dependency.global.manager.certificate_manager.location);
 
 /**
@@ -33,640 +32,344 @@ var certificate = dependency.global.require (dependency.global.manager.certifica
  * @constructor
  */
 function Config () {
-    certificate.call (this);
-    this.metaData = {};
-    this.trustedList = {pzh:{}, pzp:{}};
-    this.untrustedCert = {};
-    this.exCertList    = {};
-    this.crl = "";
-    this.policies = {};//todo: integrate policy in the configuration
-    this.userData = {name:""};
-    this.userPref = {};
-    this.serviceCache = [];
-}
+    "use strict";
+    var self = this;
+    certificate.call (self);
+    self.metaData = {};
+    self.trustedList = {pzh:{}, pzp:{}};
+    self.untrustedCert = {};
+    self.exCertList    = {};
+    self.crl = {};
+    self.policies = {};//todo: integrate policy in the configuration
+    self.userData = {};
+    self.userPref = {};
+    self.serviceCache = [];
 
-util.inherits (Config, certificate);
+    var fileList = [{folderName: null, fileName: null, object: self.metaData},
+        {folderName: null, fileName: "crl", object: self.crl},
+        {folderName: null, fileName:"trustedList", object: self.trustedList},
+        {folderName: null, fileName:"untrustedList", object: self.untrustedCert},
+        {folderName: null, fileName:"exCertList", object: self.exCertList},
+        {folderName: path.join("certificates", "internal"),fileName: null, object: self.cert.internal},
+        {folderName: path.join("certificates", "external"),fileName: null, object: self.cert.external},
+        {folderName:"userData", fileName: null, object: self.userData},
+        {folderName:"userData", fileName:"serviceCache", object: self.serviceCache},
+        {folderName:"userData", fileName:"userPref", object: self.userPref}];
 
-/**
- *
- * @param self
- * @param webinosType
- * @param inputConfig
- * @param callback
- * @return {*}
- */
-function createNewConfiguration (self, webinosType, inputConfig, callback) {
-    var cn;
-    try {
-        self.fetchConfigDetails (webinosType, inputConfig, function (status) {
-            if (status) {
-                cn = self.metaData.webinosType + ":" + self.metaData.webinosName;
-                self.generateSelfSignedCertificate (self.metaData.webinosType, cn, function (status, value) {
-                    if (!status) {
-                        logger.error ("failed generating self signed certificate -" + value);
-                        if (callback) {return callback (status, value);}
-                    } else {
-                        if (self.metaData.webinosType !== "Pzp") {
-                            cn = self.metaData.webinosType + "CA:" + self.metaData.webinosName;
-                            self.generateSelfSignedCertificate (self.metaData.webinosType + "CA", cn, function (status, value) { // Master Certificate
+    function setFriendlyName(self, friendlyName) {
+        if(friendlyName) {
+            self.metaData.friendlyName = friendlyName;
+        } else {
+            if (os.platform() && os.platform().toLowerCase() === "android" ){
+                self.metaData.friendlyName = "Mobile";
+            } else if (process.platform === "win32") {
+                self.metaData.friendlyName = "Windows PC";
+            } else if (process.platform === "darwin") {
+                self.metaData.friendlyName = "MacBook";
+            } else if (process.platform === "linux" || process.platform === "freebsd") {
+                self.metaData.friendlyName = "Linux Device";
+            } else {
+                self.metaData.friendlyName = "Webinos Device";// Add manually
+            }
+        }
+    }
+
+    function compareObjects(objA, objB){
+        if (typeof objA !== "object" || typeof objB !== "object") {
+            return false;
+        }
+
+        if ((Object.keys(objA)).length !== (Object.keys(objB)).length) {
+            return false;
+        }
+
+        for (var i = 0; i < Object.keys(objA).length; i = i + 1) {
+            if (objA[i] !== objB[i]){
+                return false;
+            }
+        }
+
+        return true;// both objects are equal
+    }
+
+    function updateWebinosConfig(folderName, type) {
+        function writeFile(config) {
+            var filePath = path.resolve (__dirname, "../../../../webinos_config.json");
+            fs.writeFileSync(filePath, JSON.stringify(config, null, " "));
+            logger.log("updated webinos config ");
+        }
+
+        if (folderName === "userData") {
+            var filePath = path.resolve (__dirname, "../../../../webinos_config.json");
+            var config = require(filePath);
+            if (type === "serviceCache") {
+               if (self.metaData.webinosType === "Pzh" && config.pzhDefaultServices.length !== self.serviceCache.length) {
+                   config.pzhDefaultServices = self.serviceCache;
+                   writeFile(config);
+               } else if (self.metaData.webinosType === "Pzp" && config.pzpDefaultServices.length !== self.serviceCache.length) {
+                   config.pzpDefaultServices = self.serviceCache;
+                   writeFile(config);
+               }
+            } else if (type === "userPref" && !compareObjects(config.ports, self.userPref.ports)) {
+                config.ports = self.userPref.ports;
+                writeFile(config);
+            }
+        }
+    }
+
+    function checkDefaultValues(webinosType) {
+        var filePath = path.resolve (__dirname, "../../../../webinos_config.json");
+        var config = require(filePath), key;
+        if (!compareObjects(config.webinos_version, self.metaData.webinos_version)) {
+            self.metaData.webinos_version = config.webinos_version;
+            self.storeDetails(null, null, self.metaData);
+        }
+        if (!compareObjects(config.ports, self.userPref.ports)) {
+            self.userPref.ports = config.ports;
+            self.storeDetails("userData", "userPref", self.userPref);
+        }
+        if (!compareObjects(config.certConfiguration, self.userData)) {
+            self.userData = config.certConfiguration;
+            self.storeDetails("userData", null, self.userData);
+        }
+        if (webinosType === "Pzh" && config.pzhDefaultServices.length !== self.serviceCache.length) {
+            self.serviceCache = config.pzhDefaultServices;
+            self.storeDetails("userData", "serviceCache", self.serviceCache);
+        } else if (webinosType === "Pzp" && config.pzpDefaultServices.length !== self.serviceCache.length) {
+            self.serviceCache = config.pzpDefaultServices;
+            self.storeDetails("userData", "serviceCache", self.serviceCache);
+        }
+    }
+
+    function storeAll() {
+        fileList.forEach (function (name) {
+            if (typeof name === "object") {
+                if(name.folderName === "userData") {
+                    if (name.fileName === null) {
+                        name.object = self.userData;
+                    }
+                    if (name.fileName === "serviceCache") {
+                        name.object = self.serviceCache;
+                    }
+                }
+                self.storeDetails(name.folderName, name.fileName, name.object);
+            }
+        });
+    }
+
+
+
+    function checkConfigExists(webinosType, inputConfig, callback) {
+        var name, i;
+        require("./webinosId.js").fetchDeviceName(webinosType, inputConfig, function (webinosName) {
+            self.metaData.webinosRoot = wPath.webinosPath() + "/" + webinosName;
+            self.metaData.webinosName = webinosName;
+            for (i = 0; i < fileList.length; i = i + 1) {
+                name = fileList[i];
+                var fileName = (name.fileName !== null) ? (name.fileName+".json"):(webinosName +".json");
+                var filePath = path.join (self.metaData.webinosRoot, name.folderName, fileName);
+                if( !fs.existsSync(filePath)){
+                    return callback(false);
+                }
+            }
+            return callback(true);
+        });
+
+    }
+    /**
+     *
+     * @param callback
+     * @return {*}
+     */
+    function createDefaultDirectories(type, callback) {
+        var dirPath, root_permission = "0744", internal_permission = "0744";
+        var webinos_root =  (type.search("Pzh") !== -1)? wPath.webinosPath()+"Pzh" :wPath.webinosPath();
+        try {
+            //In case of node 0.6, define the fs existsSync
+            if (typeof fs.existsSync === "undefined") fs.existsSync = path.existsSync;
+            if (!fs.existsSync (webinos_root)) {//If the folder doesn't exist
+                fs.mkdirSync (webinos_root, root_permission);//Create it
+             }
+
+            if (!fs.existsSync (self.metaData.webinosRoot))//If the folder doesn't exist
+                fs.mkdirSync (self.metaData.webinosRoot, internal_permission);
+            // webinos root was created, we need the following 1st level dirs
+            var list = [ path.join (self.metaData.webinosRoot, "logs"),
+                path.join (webinos_root, "wrt"),
+                path.join (self.metaData.webinosRoot, "certificates"),
+                path.join (self.metaData.webinosRoot, "policies"),
+                path.join (self.metaData.webinosRoot, "wrt"),
+                path.join (self.metaData.webinosRoot, "userData"),
+                path.join (self.metaData.webinosRoot, "keys"),
+                path.join (self.metaData.webinosRoot, "certificates", "external"),
+                path.join (self.metaData.webinosRoot, "certificates", "internal")];
+            list.forEach (function (name) {
+                if (!fs.existsSync (name)) fs.mkdirSync (name, internal_permission);
+            });
+            // Notify that we are done
+            callback (true);
+        } catch (err) {
+            //Notify that something went wrong
+            return callback (false, err.code);
+        }
+    }
+    /**
+     *
+     * @param webinosType
+     * @param inputConfig
+     * @param callback
+     */
+    function fetchDefaultWebinosConfiguration(webinosType, inputConfig, callback) {
+        var filePath = path.resolve (__dirname, "../../../../webinos_config.json"), webinos_root;
+        require("./webinosId.js").fetchDeviceName(webinosType, inputConfig, function (deviceName) {
+            self.metaData.webinosType = webinosType;
+            self.metaData.serverName = inputConfig.sessionIdentity;
+            self.metaData.webinosName = deviceName;
+
+            webinos_root =  (webinosType.search("Pzh") !== -1)? wPath.webinosPath()+"Pzh" :wPath.webinosPath();
+            self.metaData.webinosRoot = webinos_root+ "/" + self.metaData.webinosName;
+            setFriendlyName(self, inputConfig.friendlyName);
+
+            createDefaultDirectories(webinosType, function (status) {
+                if (status) {
+                    logger.log ("created default webinos directories at location : " + self.metaData.webinosRoot);
+                } else {
+                    callback (false, "failed creating webinos default directories");
+                }
+            });
+            var key, defaultConfig = require(filePath);
+            self.metaData.webinos_version = defaultConfig.webinos_version;
+            self.userPref.ports = defaultConfig.ports;
+            self.userData = defaultConfig.certConfiguration;
+            if (webinosType === "Pzh" || webinosType === "PzhCA") {
+                self.serviceCache = defaultConfig.pzhDefaultServices.slice(0);
+                self.metaData.friendlyName = self.userData.name +" ("+ self.userData.authenticator + ")";
+            } else if (webinosType === "Pzp") {
+                self.serviceCache = defaultConfig.pzpDefaultServices.slice(0);
+            }
+            if (defaultConfig.friendlyName && defaultConfig.friendlyName !== "") {
+                self.metaData.friendlyName =  userPref.friendlyName;
+            }
+            createPolicyFile();
+            storeAll();
+            callback (true);
+        });
+    }
+
+    function createNewConfiguration (webinosType, inputConfig, callback) {
+        try {
+            fetchDefaultWebinosConfiguration(webinosType, inputConfig, function (status) {
+                if (status) {
+                    var cn = self.metaData.webinosType + "CA:" + self.metaData.webinosName;
+                    self.generateSelfSignedCertificate (self.metaData.webinosType+"CA", cn, function (status, value) {
+                        if (!status) {
+                            logger.error ("failed generating self signed master certificate -" + value);
+                            if (callback) {return callback (false, "certificate manager failed in generating certificates");}
+                        } else {
+                            logger.log ("*****master certificate generated*****");
+                            cn = self.metaData.webinosType + ":" + self.metaData.webinosName;
+                            self.generateSelfSignedCertificate (self.metaData.webinosType, cn, function (status, csr) { // Master Certificate
                                 if (status) {
-                                    logger.log ("connection and master certificate generated");
-                                    self.storeAll ();
-                                    if (callback) {return callback (true);}
+                                    logger.log ("*****connection certificate generated*****");
+                                    self.generateSignedCertificate(csr, function (status, signedCert) {
+                                        if (status) {
+                                            logger.log ("*****connection certificate signed by master certificate*****");
+                                            self.cert.internal.conn.cert = signedCert;
+                                            self.storeDetails(path.join("certificates", "internal"), null, self.cert.internal);
+                                            self.storeDetails(null, "crl", self.crl);
+                                            callback(true);
+                                        } else {
+                                            callback (false);
+                                        }
+                                    });
                                 } else {
                                     logger.error ("failed generating master certificate -" + value);
                                     if (callback) {callback (false, value);}
                                 }
                             });
-                        } else {
-                            self.storeAll ();
-                            if (callback) {return callback (true);}
                         }
-                    }
-                });
-            } else {
-                logger.log ("Error reading default configuration details");
-            }
-        });
-    } catch (err) {
-        if (callback) {return callback (false, err);}
-    }
-}
-/**
- * Checks if metaData exists, if not creates a range of certificates
- * it calls generating certificate function defined in certificate manager.
- *
- * @param {function} callback It is callback function that is invoked after
- * checking/creating certificates
- */
-Config.prototype.setConfiguration = function (webinosType, inputConfig, callback) {
-    var self = this, conn_key, cn;
-    wId.fetchDeviceName (webinosType, inputConfig, function (deviceName) {
-        var webinos_root =  (webinosType.search("Pzh") !== -1)? wPath.webinosPath()+"Pzh" :wPath.webinosPath();
-        var webinosName = path.join (webinos_root, deviceName);
-        logger.addType (deviceName); // per instance this should be only set once..
-        if (typeof callback !== "function") {
-            logger.error ("callback missing");
-            return;
-        }
-
-        self.fetchMetaData (webinosName, deviceName, function (status, value) {
-            if (status && value && (value.code === "ENOENT" || value.code === "EACCES")) {//meta data does not exist
-                createNewConfiguration (self, webinosType, inputConfig, callback);
-            } else { //metaData not found
-                self.metaData = value;
-                self.fetchCertificate ("external", function (status, value) { if (status) { self.cert.external = value;} });
-                self.fetchCertificate ("internal", function (status, value) {
-                    if (status) {
-                        self.cert.internal = value;
-                        self.fetchServiceCache (function (status, value) {
-                            if (status) {
-                                self.serviceCache = value;
-                                self.fetchCrl (function (status, value) {
-                                    if (status) {
-                                        self.crl = value;
-                                        self.fetchUserData (function (status, value) {
-                                            if (status) {
-                                                self.userData = value;
-                                                self.fetchUserPref (function (status, value) {
-                                                    if (status) {
-                                                        self.userPref = value;
-                                                        self.fetchTrustedList (function (status, value) {
-                                                            if (status) {
-                                                                self.trustedList = value;
-                                                                return callback (true);
-                                                            } else {createNewConfiguration (self, webinosType, inputConfig, callback);}
-                                                        });
-                                                    } else {createNewConfiguration (self, webinosType, inputConfig, callback);}
-                                                });
-                                            } else {createNewConfiguration (self, webinosType, inputConfig, callback);}
-                                        });
-                                    } else {createNewConfiguration (self, webinosType, inputConfig, callback);}
-                                });
-                            } else {createNewConfiguration (self, webinosType, inputConfig, callback);}
-                        });
-                    } else {createNewConfiguration (self, webinosType, inputConfig, callback);}
-                });
-                self.fetchUntrustedCert (function (status, value) {
-                    if (status) {
-                        self.untrustedCert = value;
-                    }
-                })
-            }
-        });
-    });
-};
-/**
- * Store user data based on OpenId Details
- * @param user -
- */
-Config.prototype.storeUserDetails = function (user) {
-    if (this.userData && user !== null && this.userData.name !== user.displayName) {
-        this.userData.name = user.displayName;
-        this.userData.email = user.emails;
-        this.userData.country = user.country;
-        this.userData.image = user.image;
-        this.userData.authenticator = user.from;
-        this.userData.identifier = user.identifier;
-        this.storeUserData (this.userData);
-    }
-};
-/**
- *
- */
-Config.prototype.storeAll = function () {
-    var self = this;
-    self.storeCertificate (self.cert.internal, "internal");
-    self.storeCrl (self.crl);
-    self.storeTrustedList (self.trustedList);
-    self.storeExCertList(self.exCertList);
-};
-/**
- *
- * @param data
- * @param callback
- */
-function processData (data, callback) {
-    var JSONData, dataString = data.toString ();
-    if (dataString !== "") {
-        JSONData = JSON.parse (dataString);
-        callback (true, JSONData);
-    } else {
-        logger.error ("configuration files are corrupted, retrying again to create fresh configuration");
-        callback (false);
-    }
-}
-/**
- *
- * @param certificate
- * @param ext_int
- */
-Config.prototype.storeCertificate = function (certificate, ext_int) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, "certificates", ext_int, self.metaData.webinosName + ".json");
-    fs.writeFile (path.resolve (filePath), JSON.stringify (certificate, null, " "), function (err) {
-        if (err) {
-            logger.error ("failed saving " + ext_int + " certificate");
-        } else {
-            logger.log ("saved " + ext_int + " certificate");
-        }
-    });
-};
-/**
- *
- * @param ext_int
- * @param callback
- */
-Config.prototype.fetchCertificate = function (ext_int, callback) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, "certificates", ext_int, self.metaData.webinosName + ".json");
-    fs.readFile (path.resolve (filePath), function (err, data) {
-        if (err) {
-            if (ext_int !== "external") {
-                logger.error ("configuration files for certificates are corrupted, retrying again to create fresh configuration");
-            }
-            callback (false);
-        } else {
-            processData (data, callback);
-        }
-    });
-
-};
-/**
- *
- * @param data
- */
-Config.prototype.storeMetaData = function (data) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, self.metaData.webinosName + ".json");
-    fs.writeFile (path.resolve (filePath), JSON.stringify (data, null, " "), function (err) {
-        if (err) {
-            logger.error ("failed saving pzp/pzh metadata");
-        } else {
-            logger.log ("stored pzp/pzh metadata");
-        }
-    });
-};
-/**
- *
- * @param webinosRoot
- * @param webinosName
- * @param callback
- */
-Config.prototype.fetchMetaData = function (webinosRoot, webinosName, callback) {
-    var self = this;
-    var filePath = path.join (webinosRoot, webinosName + ".json");
-    fs.readFile (path.resolve (filePath), function (err, data) {
-        if (err) {
-            callback (true, err);// this is bit deceiving, we return  err as we want to trigger the certificate creation
-        } else {
-            processData (data, callback);
-        }
-    });
-};
-/**
- *
- * @param data
- */
-Config.prototype.storeCrl = function (data) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, "crl.pem");
-    fs.writeFile (path.resolve (filePath), data, function (err) {
-        if (err) {
-            logger.error ("failed saving crl");
-        } else {
-            logger.log ("saved crl");
-        }
-    });
-};
-
-/**
- *
- * @param keys
- * @param dir
- */
-Config.prototype.storeKeys = function (keys, name) {
-    var self = this;
-    var filePath = path.join(self.metaData.webinosRoot, "keys", name+".pem");
-    fs.writeFile(path.resolve(filePath), keys, function(err) {
-        if(err) {
-            logger.error("failed saving " + name +".pem");
-        } else {
-            logger.log("saved " + name +".pem");
-            //calling get hash
-            // self.getKeyHash(filePath);
-        }
-    });
-};
-
-/**
- *
- * @param callback
- */
-Config.prototype.fetchCrl = function (callback) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, "crl.pem");
-    fs.readFile (path.resolve (filePath), function (err, data) {
-        if (err) {
-            logger.error ("configuration files for CRL are corrupted, retrying again to create fresh configuration");
-            callback (false);
-        } else {
-            value = data.toString ();
-            callback (true, value);
-        }
-    });
-};
-/**
- *
- * @param data
- */
-Config.prototype.storeTrustedList = function (data) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, "trustedList.json");
-    fs.writeFile (path.resolve (filePath), JSON.stringify (data, null, " "), function (err) {
-        if (err) {
-            logger.error ("failed saving pzh/pzp in the trusted list");
-        } else {
-            logger.log ("saved pzp/pzh in the trusted list");
-        }
-    });
-};
-
-/**
- *
- * @param data
- */
-Config.prototype.storeExCertList = function (data) {
-    var self = this;
-    var filePath = path.join(self.metaData.webinosRoot,"exCertList.json");
-    fs.writeFile(path.resolve(filePath), JSON.stringify(data, null, " "), function(err) {
-        if(err) {
-            logger.error("failed saving pzh/pzp in the external certificate list");
-        } else {
-            logger.log("saved pzp/pzh in the external list");
-        }
-    });
-};
-
-
-
-/**
- *
- * @param callback
- */
-Config.prototype.fetchTrustedList = function (callback) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, "trustedList.json");
-    fs.readFile (path.resolve (filePath), function (err, data) {
-        if (err) {
-            logger.error ("configuration files for trusted list are corrupted, retrying again to create fresh configuration");
-            callback (false);
-        } else {
-            processData (data, callback);
-        }
-    });
-};
-/**
- *
- * @param data
- */
-Config.prototype.storeUntrustedCert = function (data) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, "untrustedCert.json");
-    fs.writeFile (path.resolve (filePath), JSON.stringify (data, null, " "), function (err) {
-        if (err) {
-            logger.error ("failed saving cert in the untrusted list");
-        } else {
-            logger.log ("saved pzp/pzh in the untrusted list");
-        }
-    });
-};
-/**
- *
- * @param callback
- */
-Config.prototype.fetchUntrustedCert = function (callback) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, "untrustedCert.json");
-    fs.readFile (path.resolve (filePath), function (err, data) {
-        if (err) {
-            callback (false);
-        } else {
-            processData (data, callback);
-        }
-    });
-};
-
-/**
- *
- * @param callback
- */
-Config.prototype.fetchExCertList = function (callback) {
-    var self = this;
-    var filePath = path.join(self.metaData.webinosRoot, "exCertList.json");
-    fs.readFile(path.resolve(filePath), function(err, data) {
-        if(err) {
-            logger.error("configuration files for external cert list are corrupted, retrying again to create fresh configuration");
-            callback(false);
-        } else {
-            processData(data,callback);
-        }
-    });
-};
-/**
- *
- * @param data
- */
-Config.prototype.storeUserData = function (data) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, "userData", self.metaData.webinosName + ".json");
-    fs.writeFile (path.resolve (filePath), JSON.stringify (data, null, " "), function (err) {
-        if (err) {
-            logger.error ("failed saving user details");
-        } else {
-            logger.log ("saved user details");
-        }
-    });
-};
-/**
- *
- * @param callback
- */
-Config.prototype.fetchUserData = function (callback) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, "userData", self.metaData.webinosName + ".json");
-    fs.readFile (path.resolve (filePath), function (err, data) {
-        if (err) {
-            logger.error ("configuration files for user data are corrupted, retrying again to create fresh configuration");
-            callback (false);
-        } else {
-            processData (data, callback);
-        }
-    });
-};
-/**
- *
- * @param data
- */
-Config.prototype.storeServiceCache = function (data) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, "userData", self.metaData.webinosName + "_serviceCache.json");
-    fs.writeFile (path.resolve (filePath), JSON.stringify (data, null, " "), function (err) {
-        if (err) {
-            logger.error ("failed saving service cache");
-        } else {
-            logger.log ("saved service cache");
-        }
-    });
-};
-/**
- *
- * @param callback
- */
-Config.prototype.fetchServiceCache = function (callback) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, "userData", self.metaData.webinosName + "_serviceCache.json");
-    fs.readFile (path.resolve (filePath), function (err, data) {
-        if (err) {
-            logger.error ("configuration files for service cache are corrupted, retrying again to create fresh configuration");
-            callback (false);
-        } else {
-            processData (data, callback);
-        }
-    });
-};
-/**
- *
- * @param data
- */
-Config.prototype.storeUserPref = function (data) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, "userData", self.metaData.webinosName + "_pref.json");
-    fs.writeFile (path.resolve (filePath), JSON.stringify (data, null, " "), function (err) {
-        if (err) {
-            logger.error ("failed saving user preferences");
-        } else {
-            logger.log ("saved user preferences");
-        }
-    });
-};
-/**
- *
- * @param callback
- */
-Config.prototype.fetchUserPref = function (callback) {
-    var self = this;
-    var filePath = path.join (self.metaData.webinosRoot, "userData", self.metaData.webinosName + "_pref.json");
-    fs.readFile (path.resolve (filePath), function (err, data) {
-        if (err) {
-            logger.error ("configuration files for user pref are corrupted, retrying again to create fresh configuration");
-            callback (false);
-        } else {
-            processData (data, callback);
-        }
-    });
-};
-/**
- *
- * @param callback
- * @return {*}
- */
-Config.prototype.createDirectories = function (type, callback) {
-    var self = this, dirPath, root_permission = 0744, internal_permission = 0744;
-    var webinos_root =  (type.search("Pzh") !== -1)? wPath.webinosPath()+"Pzh" :wPath.webinosPath();
-    try {
-        //In case of node 0.6, define the fs existsSync
-        if (typeof fs.existsSync === "undefined") fs.existsSync = path.existsSync;
-        if (!fs.existsSync (webinos_root)) {//If the folder doesn't exist
-            fs.mkdirSync (webinos_root, root_permission);//Create it
-        }
-
-        if (!fs.existsSync (self.metaData.webinosRoot))//If the folder doesn't exist
-            fs.mkdirSync (self.metaData.webinosRoot, internal_permission);
-        // webinos root was created, we need the following 1st level dirs
-        var list = [ path.join (self.metaData.webinosRoot, "logs"),
-            path.join (webinos_root, "wrt"),
-            path.join (self.metaData.webinosRoot, "certificates"),
-            path.join (self.metaData.webinosRoot, "policies"),
-            path.join (self.metaData.webinosRoot, "wrt"),
-            path.join (self.metaData.webinosRoot, "userData"),
-            path.join (self.metaData.webinosRoot, "keys"),
-            path.join (self.metaData.webinosRoot, "certificates", "external"),
-            path.join (self.metaData.webinosRoot, "certificates", "internal")];
-        list.forEach (function (name) {
-            if (!fs.existsSync (name)) fs.mkdirSync (name, internal_permission);
-        });
-        // Notify that we are done
-        callback (true);
-    } catch (err) {
-        //Notify that something went wrong
-        return callback (false, err.code);
-    }
-};
-/**
- *
- * @param self
- */
-Config.prototype.createPolicyFile = function (self) {
-    // policy file
-    fs.readFile (path.join (self.metaData.webinosRoot, "policies", "policy.xml"), function (err) {
-        if (err && err.code === "ENOENT") {
-            var data;
-            try {
-                data = fs.readFileSync (path.resolve (__dirname, "../../manager/policy_manager/defaultpolicy.xml"));
-            }
-            catch (e) {
-                logger.error ("Default policy not found");
-                data = "<policy combine=\"first-applicable\" description=\"denyall\">\n<rule effect=\"deny\"></rule>\n</policy>";
-            }
-            fs.writeFileSync (path.join (self.metaData.webinosRoot, "policies", "policy.xml"), data);
-        }
-    });
-};
-
-function setFriendlyName(self, friendlyName) {
-    if(friendlyName) {
-        self.metaData.friendlyName = friendlyName;
-    } else {
-        if (os.platform() && os.platform().toLowerCase() === "android" ){
-            self.metaData.friendlyName = "Mobile";
-        } else if (process.platform === "win32") {
-            self.metaData.friendlyName = "Windows PC";
-        } else if (process.platform === "darwin") {
-            self.metaData.friendlyName = "MacBook";
-        } else if (process.platform === "linux" || process.platform === "freebsd") {
-            self.metaData.friendlyName = "Linux Device";
-        } else {
-            self.metaData.friendlyName = "Webinos Device";// Add manually
-        }
-    }
-
-}
-/**
- *
- * @param webinosType
- * @param inputConfig
- * @param callback
- */
-Config.prototype.fetchConfigDetails = function (webinosType, inputConfig, callback) {
-    var self = this, webinos_root;
-    var filePath = path.resolve (__dirname, "../../../../webinos_config.json");
-    wId.fetchDeviceName (webinosType, inputConfig, function (deviceName) {
-        self.metaData.webinosType = webinosType;
-        self.metaData.serverName = inputConfig.sessionIdentity;
-        self.metaData.webinosName = deviceName;
-
-        webinos_root =  (webinosType.search("Pzh") !== -1)? wPath.webinosPath()+"Pzh" :wPath.webinosPath();
-        self.metaData.webinosRoot = webinos_root+ "/" + self.metaData.webinosName;
-        setFriendlyName(self, inputConfig.friendlyName);
-        self.createDirectories (webinosType, function (status) {
-            if (status) {
-                logger.log ("created default webinos directories at location : " + self.metaData.webinosRoot);
-            } else {
-                callback (false, "failed creating directories");
-            }
-        });
-        fs.readFile (filePath, function (err, data) {
-            if (!err) {
-                var key, userPref = JSON.parse (data.toString ());
-                self.userPref.ports = {};
-                self.userPref.ports.provider = userPref.ports.provider;
-                self.userPref.ports.provider_webServer = userPref.ports.provider_webServer;
-                self.userPref.ports.pzp_webSocket = userPref.ports.pzp_webSocket;
-                self.userPref.ports.pzp_tlsServer = userPref.ports.pzp_tlsServer;
-                self.userPref.ports.pzp_zeroConf = userPref.ports.pzp_zeroConf;
-                if (webinosType === "Pzh" || webinosType === "PzhCA") {
-                    self.storeUserDetails(inputConfig.user);
-                    self.metaData.friendlyName = self.userData.name +" ("+ self.userData.authenticator + ")";
+                    });
                 } else {
-                    self.userData.email = userPref.certConfiguration.email;
+                    logger.log ("Error reading default configuration details");
                 }
-                if (userPref.friendlyName && userPref.friendlyName !== "") {
-                    self.metaData.friendlyName =  userPref.friendlyName;
-                }
-                self.userData.country = userPref.certConfiguration.country;
-                self.userData.state = userPref.certConfiguration.state;
-                self.userData.city = userPref.certConfiguration.city;
-                self.userData.orgName = userPref.certConfiguration.orgname;
-                self.userData.orgUnit = userPref.certConfiguration.orgunit;
-                self.userData.cn = userPref.certConfiguration.cn;
-                if (webinosType === "Pzh") {
-                    for (key in userPref.pzhDefaultServices) {
-                        self.serviceCache.push ({"name":userPref.pzhDefaultServices[key].name, "params":userPref.pzpDefaultServices[key].params});
-                    }
-                } else if (webinosType === "Pzp") {
-                    for (key = 0; key < userPref.pzpDefaultServices.length; key = key + 1) {
-                        if (userPref.pzpDefaultServices[key].name === "file") {
-                            userPref.pzpDefaultServices[key].params = { getPath:function () { return self.metaData.webinosRoot; } };
-                        }
-                        self.serviceCache.push ({"name":userPref.pzpDefaultServices[key].name, "params":userPref.pzpDefaultServices[key].params});
-                    }
-                }
-            } else { // We failed in reading configuration file, assign defaults
-                self.userPref.ports = {};
-                self.userPref.ports.provider = 80;
-                self.userPref.ports.provider_webServer = 443;
-                self.userPref.ports.pzp_webSocket = 8080;
-                self.userPref.ports.pzp_tlsServer = 8040;
-                self.userPref.ports.pzp_zeroConf = 4321;
-                self.userData.country = "UK";
-                self.userData.email = "hello@webinos.org";
-                self.userData.state = "";
-                self.userData.city = "";
-                self.userData.orgName = "";
-                self.userData.orgUnit = "";
-                self.userData.cn = "";
+            });
+        } catch (err) {
+            logger.error(err);
+            if (callback) {callback (false, err);}
+        }
+    }
+    /**
+     * Checks if metaData exists, if not creates a range of certificates
+     * it calls generating certificate function defined in certificate manager.
+     *
+     * @param {function} callback It is callback function that is invoked after
+     * checking/creating certificates
+     */
+    this.setConfiguration = function (webinosType, inputConfig, callback) {
+        checkConfigExists(webinosType, inputConfig, function(status) {
+            if(status) {
+                fileList.forEach(function(name){
+                    self.fetchDetails(name.folderName, name.fileName, name.object);
+                });
+                checkDefaultValues(webinosType);
+                callback(true);
+            } else {
+                createNewConfiguration (webinosType, inputConfig, callback);
             }
-
-            self.storeMetaData (self.metaData);
-            self.storeUserData (self.userData);
-            self.storeUserPref (self.userPref);
-            self.storeServiceCache (self.serviceCache);
-            self.storeUntrustedCert (self.untrustedCert);
-            self.createPolicyFile (self);
-            callback (true);
         });
-    });
-};
+    };
+
+    this.storeKeys = function (keys, name) {
+        var filePath = path.join(self.metaData.webinosRoot, "keys", name+".pem");
+        fs.writeFile(path.resolve(filePath), keys, function(err) {
+            if(err) {
+                logger.error("failed saving " + name +".pem");
+            } else {
+                logger.log("saved " + name +".pem");
+                //calling get hash
+                // self.getKeyHash(filePath);
+            }
+        });
+    };
+    /**
+     *
+     * @param data
+     */
+    this.storeDetails = function (folderName, type, data) {
+        var fileName = (type !== null) ? type+".json":self.metaData.webinosName +".json";
+        var filePath = path.join (self.metaData.webinosRoot, folderName, fileName);
+        fs.writeFile (path.resolve (filePath), JSON.stringify (data, null, " "), function (err) {
+            if (err) {
+                logger.error ("failed saving in "+ folderName);
+            } else {
+                logger.log ("saved "+ filePath);
+                updateWebinosConfig(folderName, type);
+            }
+        });
+    };
+    /**
+     *
+     * @param callback
+     */
+    this.fetchDetails = function (folderName, type, assignValue) {
+        var fileName = (type !== null) ? (type+".json"):(self.metaData.webinosName +".json");
+        var filePath = path.join (self.metaData.webinosRoot, folderName, fileName);
+        try {
+            var data = fs.readFileSync (path.resolve (filePath));
+            var dataString = data.toString ();
+            if (dataString !== "") {
+                data = JSON.parse(dataString);
+                for (var key in data) {
+                    assignValue[key] = data[key];
+                }
+            }
+        } catch(err) {
+            logger.log(err);
+            logger.error ("configuration file "+ filePath+" is corrupted, retrying again to create fresh configuration");
+        }
+    };
+}
+
+util.inherits (Config, certificate);
 
 module.exports = Config;

--- a/webinos/web_root/testbed/client.html
+++ b/webinos/web_root/testbed/client.html
@@ -41,9 +41,9 @@ $ (document).ready (function () {
         }
     }
     function webinosVersion (msg) {
-        var currentVersion = msg.payload.message.split ("-")[0];
-        var sha1 = msg.payload.message.split ("-")[2];
-        $ ("#webinosVersion").html ("<ul align=\"right\"> Webinos Version-" + currentVersion + " (Commit ID-" + sha1 + ") </ul>");
+        var currentVersion = msg.payload.message;
+        $ ("#webinosVersion").html ("<ul align=\"right\"> Webinos Version - "+currentVersion.tag+"."+
+                currentVersion.num_commit + "( CommitId-"+ currentVersion.commit_id+") </ul>");
     }
     webinos.session.addListener ('webinosVersion', webinosVersion);
     function pzhDisconnected () {

--- a/webinos_config.json
+++ b/webinos_config.json
@@ -35,10 +35,10 @@
       "params":{}
     },
     {
-        "name"  :"app2app",
-        "params":{
-            "scope":"pzp"
-        }
+      "name"  :"app2app",
+      "params":{
+          "scope":"pzp"
+      }
     },
     {
       "name"  :"webnotification",
@@ -126,5 +126,10 @@
     "cn"     :"",
     "email"  :"hello@webinos.org"
   },
-  "friendlyName":""
+  "friendlyName":"",
+  "webinos_version": {
+    "tag": "v0.8.0",
+    "num_commit": "15",
+    "commit_id": "gba7314e"
+  }
 }

--- a/webinos_pzh.js
+++ b/webinos_pzh.js
@@ -30,10 +30,9 @@ var argv = require('optimist')
 var _pzh_provider = new pzh_provider(argv.host, argv.name);
 _pzh_provider.startProvider(function(result, details) {
   if (result) {
-    console.log("ZONE PROVIDER STARTED");
     pzh_web.start(argv.host, argv.name);
   } else {
-    console.error("ZONE PROVIDER FAILED TO START "+ details);
+    console.error("ZONE PROVIDER FAILED TO START "+ details, 'color:red');
   }
 });
 


### PR DESCRIPTION
- As part of running grunt, webinos version is added in webinos_config.json.
- Update is also done to package.json if webinos version changes.
- webinos_config.json can be now updated for port changes.
- Configuration uses a single function to store and retrieve details.
- Webinos_config.json is checked at every time webinos is started to see differences.
- SetConfiguration generates CA for PZP and PZH. PZPCA is related to WP-39 but changes are introduced here.
- Impacts PZP has master certificate signed by PZH. PZH now needs to load PZP signed certificate to allow authentication.
  -Introduces getCertType and getKeyId functions to fetch client/server certificate type and key name respectively.
- Removes declaring client or server certificate during signing process.

Jira Issue: 778
