### PR TITLE
WP-805 fix manifest2policy tests

### DIFF
--- a/tools/travis/unit-tests.sh
+++ b/tools/travis/unit-tests.sh
@@ -39,7 +39,6 @@ run_unit_test(){
 #'./webinos/core/xmpp-pzp/test/jasmine',
 #'./webinos/core/manager/certificate_manager/test/jasmine',
 #'./webinos/core/manager/keystore/test/jasmine',
-#'./webinos/core/manager/widget_manager/test/jasmine',
 #'./webinos/core/manager/context_manager/test/jasmine',
 #'./webinos/core/manager/messaging/test/jasmine',
 #'./webinos/core/util/test/jasmine',
@@ -53,7 +52,7 @@ run_unit_test(){
 #'./webinos/web_root/tests/test_frameworks/jasmine-1.2.0'
 
 #whitelist=('./webinos/core/manager/policy_manager/test/jasmine')
-whitelist=( "./webinos/core/manager/policy_manager/test/jasmine" )
+whitelist=( "./webinos/core/manager/policy_manager/test/jasmine" "./webinos/core/manager/widget_manager/test/jasmine" )
 #function to determine whether tests will be run on the given component
 #currently, all tests under included in the whitelist will not be filtered
 filter(){

--- a/tools/travis/unit-tests.sh
+++ b/tools/travis/unit-tests.sh
@@ -52,11 +52,12 @@ run_unit_test(){
 #'./webinos/web_root/tests/test_frameworks/jasmine-1.2.0'
 
 #whitelist=('./webinos/core/manager/policy_manager/test/jasmine')
-whitelist=( "./webinos/core/manager/policy_manager/test/jasmine" "./webinos/core/manager/widget_manager/test/jasmine" )
+whitelist=( "./webinos/core/manager/policy_manager/test/jasmine"
+	"./webinos/core/manager/widget_manager/test/jasmine" )
 #function to determine whether tests will be run on the given component
 #currently, all tests under included in the whitelist will not be filtered
 filter(){
-	if contains "$1" "$whitelist"
+	if contains "$1" "${whitelist[@]}"
 	then
 		return 0
 	else

--- a/webinos/core/manager/widget_manager/test/jasmine/manifest2policy_test.spec.js
+++ b/webinos/core/manager/widget_manager/test/jasmine/manifest2policy_test.spec.js
@@ -23,7 +23,7 @@ var path = require('path');
 var m2p = require (path.join(__dirname,
                              '../../lib/manifest2policy/manifest2policy.js'));
 
-var manifest = 'manifestExample.xml';
+var manifest = path.join(__dirname, 'manifestExample.xml');
 var appId = '123';
 var optionalFeature = ['http://webinos.org/api/notifications'];
 


### PR DESCRIPTION
http://jira.webinos.org/browse/WP-805
- fixed manifest2policy jasmine tests (in widget_manager)
- whitelisted widget_manager jasmine tests
- fixed unit-tests.sh script
