### PR TITLE
Move PZP ConfigActivity off launcher menu.

### DIFF
--- a/webinos/platform/android/app/AndroidManifest.xml
+++ b/webinos/platform/android/app/AndroidManifest.xml
@@ -28,7 +28,6 @@
                   android:label="@string/app_name">
             <intent-filter>
                 <action android:name="org.webinos.app.MAIN" />
-                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
         <activity android:name="org.webinos.app.pzp.ConfigActivity"
@@ -39,7 +38,6 @@
                   android:allowTaskReparenting="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <activity android:name="org.webinos.impl.PromptActivity"

--- a/webinos/platform/android/app/res/layout/activity_widget_list.xml
+++ b/webinos/platform/android/app/res/layout/activity_widget_list.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical" >
+
+    <ListView
+        android:id="@android:id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:drawSelectorOnTop="false" />
+
+    <TextView
+        android:id="@android:id/empty"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center_vertical"
+        android:gravity="center"
+        android:text="@string/loading_apps"
+        android:textSize="16sp"
+        android:textStyle="bold" />
+
+</LinearLayout>

--- a/webinos/platform/android/app/res/values/strings.xml
+++ b/webinos/platform/android/app/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Anode</string>
+    <string name="app_name">Webinos</string>
     <string name="pzp_activity_name">PZP</string>
     <string name="initialising_runtime">Initialising Webinos Runtime</string>
     <string name="start">Start</string>
@@ -38,4 +38,10 @@
     <string name="menu_check_for_updates">Check for updates</string>
     <string name="menu_details">Details</string>
     <string name="nfc_instruction">Tap NFC compatible item with the back of your device</string>
+    <string name="scan_sd_card">Scan SD card</string>
+    <string name="pzp_settings">Settings</string>
+    <string name="not_yet_implemented">Not yet implemented</string>
+    <string name="no_apps_installed">No applications installed</string>
+    <string name="loading_apps">Loading applications</string>
+    
 </resources>

--- a/webinos/platform/android/app/src/org/webinos/app/wrt/ui/WidgetListActivity.java
+++ b/webinos/platform/android/app/src/org/webinos/app/wrt/ui/WidgetListActivity.java
@@ -28,6 +28,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.webinos.app.R;
+import org.webinos.app.pzp.ConfigActivity;
 import org.webinos.app.wrt.mgr.WidgetManagerImpl;
 import org.webinos.app.wrt.mgr.WidgetManagerService;
 import org.webinos.util.AssetUtils;
@@ -51,6 +52,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView.AdapterContextMenuInfo;
 import android.widget.ListView;
+import android.widget.TextView;
 import android.widget.Toast;
 
 public class WidgetListActivity extends ListActivity implements WidgetManagerService.LaunchListener, WidgetManagerImpl.EventListener {
@@ -66,6 +68,7 @@ public class WidgetListActivity extends ListActivity implements WidgetManagerSer
 
 	static final int SCAN_MENUITEM_ID     = 0;
 	static final int CONTEXT_MENUITEM_ID  = 1;
+	static final int PZP_MENUITEM_ID      = 2;
 	static final int STORES_MENUITEM_BASE = 100;
 	static final int SCANNING_DIALOG      = 0;
 	static final int NO_WIDGETS_DIALOG    = 1;
@@ -80,6 +83,8 @@ public class WidgetListActivity extends ListActivity implements WidgetManagerSer
 	@Override
 	public void onCreate(Bundle bundle) {
 		super.onCreate(bundle);
+		setContentView(R.layout.activity_widget_list);
+
 		registerForContextMenu(getListView());
 		asyncRefreshHandler = new Handler() {
 			@Override
@@ -129,10 +134,10 @@ public class WidgetListActivity extends ListActivity implements WidgetManagerSer
 			startActivity(intent);
 			return true;
 		case R.id.menu_check_for_updates:
-			Toast.makeText(this, "Not yet implemented", Toast.LENGTH_SHORT).show();
+			Toast.makeText(this, getString(R.string.not_yet_implemented), Toast.LENGTH_SHORT).show();
 			return true;
 		case R.id.menu_details:
-			Toast.makeText(this, "Not yet implemented", Toast.LENGTH_SHORT).show();
+			Toast.makeText(this, getString(R.string.not_yet_implemented), Toast.LENGTH_SHORT).show();
 			return true;
 		default:
 			return super.onContextItemSelected(item);
@@ -143,7 +148,8 @@ public class WidgetListActivity extends ListActivity implements WidgetManagerSer
 	public boolean onCreateOptionsMenu(Menu menu) {
 		super.onCreateOptionsMenu(menu);
 		menu.setQwertyMode(true);
-		menu.add(0, SCAN_MENUITEM_ID, 0, "Scan SD card");
+		menu.add(0, SCAN_MENUITEM_ID, 0, getString(R.string.scan_sd_card));
+		menu.add(0, PZP_MENUITEM_ID, 0, getString(R.string.pzp_settings));
 		/* add any configured stores to the menu */
 		if(stores != null) {
 			for(int i = 0; i < stores.length; i++) {
@@ -159,6 +165,10 @@ public class WidgetListActivity extends ListActivity implements WidgetManagerSer
 		int itemId = item.getItemId();
 		if(itemId == SCAN_MENUITEM_ID) {
 			scanner.scan();
+			return true;
+		}
+		if(itemId == PZP_MENUITEM_ID) {
+			startActivity(new Intent(this, ConfigActivity.class));
 			return true;
 		}
 		if(itemId >= STORES_MENUITEM_BASE) {
@@ -197,6 +207,7 @@ public class WidgetListActivity extends ListActivity implements WidgetManagerSer
 	private void initList() {
 		ids = mgr.getInstalledWidgets();
 		setListAdapter(new WidgetListAdapter(this, ids));
+		((TextView)findViewById(android.R.id.empty)).setText(getString(R.string.no_apps_installed));
 	}
 
 	@Override


### PR DESCRIPTION
Jira issue: WP-831

The PZP ConfigActivity is now accessed from a 'Settings ...' menu option
on the WidgetList activity, and the launcher entry is removed.

Also some cosmetic improvement to the WidgetList activity to show an
indication when the list is empty.
