### PR TITLE
improve filter for zoneId

### DIFF
--- a/webinos/core/api/servicedisco/lib/rpc_servicedisco.js
+++ b/webinos/core/api/servicedisco/lib/rpc_servicedisco.js
@@ -185,9 +185,10 @@
 					// filter results for zoneId
 					if (filter && typeof filter.zoneId === 'object') {
 						function hasZoneId(sv) {
+							// extract the openid account (user@foo.bar)
+							var zoneId = /[^_]+_([^\/]+)/.exec(sv.serviceAddress);
 							for (var i=0; i<filter.zoneId.length; i++) {
-								var found = sv.serviceAddress.indexOf(filter.zoneId[i]) !== -1 ? true : false;
-								if (found) return true;
+								if (zoneId && zoneId[1] === filter.zoneId[i]) return true;
 							}
 							return false;
 						}


### PR DESCRIPTION
if the filter param to findServices has a zoneId property that is a string
array then these strings will be matched against the personal zone id,
which is the openid user account.

previously that zoneId could be a partial match. with this commit this
matches only if a string in the zoneId filter propertry is equal to the
zone id.

Example:
// will match services from zone foo@bar.baz
var filter = { zoneId: ['foo@bar.baz'] };

Jira-issue: http://jira.webinos.org/browse/WP-783
