### PR TITLE
Wp 851 disconnect events for rpc services

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   , "url" : "http://github.com/webinos/Webinos-Platform.git"
   }
 , "dependencies" :
-  { "webinos-jsonrpc2" : "*"
+  { "webinos-jsonrpc2" : "~0.8.1"
   , "schema" : "0.x.x"
   , "JSV" : "4.x.x"
   , "sax" : "0.x.x"

--- a/webinos/core/api/geolocation/lib/webinos.geolocation.rpc.js
+++ b/webinos/core/api/geolocation/lib/webinos.geolocation.rpc.js
@@ -97,6 +97,10 @@ var GeolocationModule = function(rpcHandler, params) {
 		implModule.clearWatch(params, successCB, errorCB, objectRef);
 	};
 	
+	// Add listener for internal webinos disconnect events
+	this._addListener('disconnected', function(event) {
+		if (implModule.handleEvent) implModule.handleEvent(event);
+	});
 };
 
 GeolocationModule.prototype = new RPCWebinosService;

--- a/webinos/core/manager/messaging/lib/messagehandler.js
+++ b/webinos/core/manager/messaging/lib/messagehandler.js
@@ -163,6 +163,18 @@
 	};
 
 	/**
+	 * Returns true if msg is a msg for app on wrt connected to this pzp.
+	 */
+	function isLocalAppMsg(msg) {
+		if (/(?:\/[a-f0-9]+){2,}/.exec(msg.to) // must include /$id/$otherid to be wrt
+				&& /\//.exec(this.ownSessionId) // must include "/" to be pzp
+				&& msg.to.substr(0, this.ownSessionId.length) === this.ownSessionId) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Somehow finds out the PZH address and returns it?
 	 */
 	function getPzhAddr(message) {
@@ -232,6 +244,13 @@
 		if ((!this.clients[session1]) && (!this.clients[session2])) { // not registered either way
 			logger.log("session not set up");
 			var forwardto = getPzhAddr.call(this, message);
+
+			if (isLocalAppMsg.call(this, message)) {
+				// msg from this pzp to wrt previously connected to this pzp
+				console.log('drop message, wrt disconnected');
+				return;
+			}
+
 			logger.log("message forward to:" + forwardto);
 			this.sendMsg(message, forwardto);
 		}
@@ -297,6 +316,13 @@
 				if ((!this.clients[session1]) && (!this.clients[session2])) {
 					logObj(message, "Sender, receiver not registered either way");
 					var forwardto = getPzhAddr.call(this, message);
+
+					if (isLocalAppMsg.call(this, message)) {
+						// msg from other pzp to wrt previously connected to this pzp
+						console.log('drop message, wrt disconnected');
+						return;
+					}
+
 					logger.log("message forward to:" + forwardto);
 					this.sendMsg(message, forwardto);
 				}

--- a/webinos/core/manager/messaging/lib/messagehandler.js
+++ b/webinos/core/manager/messaging/lib/messagehandler.js
@@ -320,6 +320,16 @@
 					if (isLocalAppMsg.call(this, message)) {
 						// msg from other pzp to wrt previously connected to this pzp
 						console.log('drop message, wrt disconnected');
+						var m = {
+							type: 'mprop',
+							to: message.resp_to,
+							from: this.ownSessionId,
+							payload: {
+								name: 'disconnected',
+								sessionId: message.to
+							}
+						}
+						this.sendMsg(m, message.resp_to);
 						return;
 					}
 

--- a/webinos/core/manager/messaging/test/jasmine/messaging.spec.js
+++ b/webinos/core/manager/messaging/test/jasmine/messaging.spec.js
@@ -22,11 +22,11 @@ describe('manager.messaging', function() {
 	it('has setSendMessage function', function() {
 		expect(messageHandler.setSendMessage).toBeFunction();
 	});
-	it('has setGetOwnId function', function() {
-		expect(messageHandler.setGetOwnId).toBeFunction();
+	it('has setOwnSessionId function', function() {
+		expect(messageHandler.setOwnSessionId).toBeFunction();
 	});
-	it('has getOwnId function', function() {
-		var id = messageHandler.getOwnId();
+	it('has getOwnSessionId function', function() {
+		var id = messageHandler.getOwnSessionId();
 		expect(id).toBeNull();
 	});
 	it('has setSeparator function', function() {

--- a/webinos/core/manager/messaging/test/jasmine/messaging.spec.js
+++ b/webinos/core/manager/messaging/test/jasmine/messaging.spec.js
@@ -1,12 +1,8 @@
-describe('common.manager.messaging', function() {
+describe('manager.messaging', function() {
 
-	var webinos = require("find-dependencies")(__dirname);
-
-	var RPCHandler = webinos.global.require(webinos.global.rpc.location).RPCHandler;
-	var rpcHandler = new RPCHandler();
-
-	var MessageHandler = webinos.global.require('common/manager/messaging').MessageHandler;
-	var messageHandler = new MessageHandler(rpcHandler);
+	var mockRpcHandler = jasmine.createSpyObj('rpcHandler', ['setMessageHandler', 'handleMessage']);
+	var MessageHandler = require('../../lib/messagehandler.js').MessageHandler;
+	var messageHandler = new MessageHandler(mockRpcHandler);
 
 	beforeEach(function() {
 		this.addMatchers({
@@ -26,12 +22,6 @@ describe('common.manager.messaging', function() {
 	it('has setSendMessage function', function() {
 		expect(messageHandler.setSendMessage).toBeFunction();
 	});
-	it('has sendMessage function', function() {
-		expect(messageHandler.sendMessage).toBeFunction();
-	});
-	it('has setObjectRef function', function() {
-		expect(messageHandler.setObjectRef).toBeFunction();
-	});
 	it('has setGetOwnId function', function() {
 		expect(messageHandler.setGetOwnId).toBeFunction();
 	});
@@ -42,38 +32,11 @@ describe('common.manager.messaging', function() {
 	it('has setSeparator function', function() {
 		expect(messageHandler.setSeparator).toBeFunction();
 	});
-
-	it('has createMessage function', function() {
-
-		var options = {
-		register: false
-	 	,type: "JSONRPC"
-	 	,id: 36
-	 	,from: "sender"
-	 	,to: "receiver"
-	 	,resp_to:"sender"
-	 	};
-
-		var message = {};
-		message = messageHandler.createMessage(options);
-		expect(message.register).toEqual(false);
-		expect(message.type).toEqual("JSONRPC");
-		expect(message.id).toEqual(36);
-		expect(message.from).toEqual("sender");
-		expect(message.to).toEqual("receiver");
-		expect(message.resp_to).toEqual("sender");
-	});
-	it('has createMessageId function', function() {
-		var message={};
-		messageHandler.createMessageId(message);
-		expect(message.id).toBeNumber();
-	});
-
-	it('has registerSender function', function() {
+	it('has createRegisterMessage function', function() {
 		var from="sender";
 		var to="receiver";
 		var message={};
-		message=messageHandler.registerSender(from,to);
+		message=messageHandler.createRegisterMessage(from,to);
 		expect(message.register).toEqual(true);
 		expect(message.from).toEqual("sender");
 		expect(message.to).toEqual("receiver");

--- a/webinos/core/pzh/lib/pzh_otherManager.js
+++ b/webinos/core/pzh/lib/pzh_otherManager.js
@@ -241,6 +241,13 @@ var Pzh_RPC = function (_parent) {
                         break;
                 }
             } else {
+                if (validMsgObj.to === _parent.pzh_state.sessionId
+                        && validMsgObj.type === 'mprop'
+                        && validMsgObj.payload.name === 'disconnected') {
+                    logger.log('msg dropped for: ' + validMsgObj.payload.sessionId);
+                    self.registry.emitEvent(validMsgObj.payload);
+                    return;
+                }
                 try {
                     self.messageHandler.onMessageReceived (validMsgObj, validMsgObj.to);
                 } catch (err2) {

--- a/webinos/core/pzh/lib/pzh_otherManager.js
+++ b/webinos/core/pzh/lib/pzh_otherManager.js
@@ -145,7 +145,6 @@ var Pzh_RPC = function (_parent) {
         };
         // Setting message handler to work with pzh instance
         self.messageHandler.setGetOwnId (_parent.pzh_state.sessionId);
-        self.messageHandler.setObjectRef (_parent);
         self.messageHandler.setSendMessage (messageHandlerSend);
         self.messageHandler.setSeparator ("/");
     };

--- a/webinos/core/pzh/lib/pzh_otherManager.js
+++ b/webinos/core/pzh/lib/pzh_otherManager.js
@@ -144,7 +144,7 @@ var Pzh_RPC = function (_parent) {
             _parent.sendMessage (message, address);
         };
         // Setting message handler to work with pzh instance
-        self.messageHandler.setGetOwnId (_parent.pzh_state.sessionId);
+        self.messageHandler.setOwnSessionId (_parent.pzh_state.sessionId);
         self.messageHandler.setSendMessage (messageHandlerSend);
         self.messageHandler.setSeparator ("/");
     };

--- a/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
+++ b/webinos/core/pzh/lib/pzh_tlsSessionHandling.js
@@ -95,7 +95,7 @@ var Pzh = function () {
                 self.config.storeDetails(null, "trustedList", self.config.trustedList);
             }
             _conn.id = _pzpId;
-            msg = self.pzh_otherManager.messageHandler.registerSender (self.pzh_state.sessionId, _pzpId);
+            msg = self.pzh_otherManager.messageHandler.createRegisterMessage (self.pzh_state.sessionId, _pzpId);
             self.sendMessage (msg, _pzpId);
             self.sendUpdateToAll(self.pzh_state.sessionId);
             self.pzh_otherManager.syncStart(_pzpId);
@@ -123,7 +123,7 @@ var Pzh = function () {
                 _conn.id = _pzhId;
 
                 setTimeout (function () {
-                    msg = self.pzh_otherManager.messageHandler.registerSender(self.config.metaData.serverName, _pzhId);
+                    msg = self.pzh_otherManager.messageHandler.createRegisterMessage(self.config.metaData.serverName, _pzhId);
                     self.sendMessage (msg, _pzhId);
                     self.sendUpdateToAll(self.pzh_state.sessionId);
                     self.pzh_otherManager.registerServices (_pzhId);

--- a/webinos/core/pzp/lib/pzp_otherManager.js
+++ b/webinos/core/pzp/lib/pzp_otherManager.js
@@ -291,6 +291,13 @@ var Pzp_OtherManager = function (_parent) {
                         break;
                 }
             } else {
+                if (validMsgObj.to === _parent.pzp_state.sessionId
+                        && validMsgObj.type === 'mprop'
+                        && validMsgObj.payload.name === 'disconnected') {
+                    logger.log('msg dropped for: ' + validMsgObj.payload.sessionId);
+                    self.registry.emitEvent(validMsgObj.payload);
+                    return;
+                }
                 self.messageHandler.onMessageReceived (validMsgObj, validMsgObj.to);
             }
         });

--- a/webinos/core/pzp/lib/pzp_otherManager.js
+++ b/webinos/core/pzp/lib/pzp_otherManager.js
@@ -200,7 +200,7 @@ var Pzp_OtherManager = function (_parent) {
             _parent.sendMessage (message, address);
         };
         self.rpcHandler.setSessionId (_parent.pzp_state.sessionId);
-        self.messageHandler.setGetOwnId (_parent.pzp_state.sessionId);
+        self.messageHandler.setOwnSessionId (_parent.pzp_state.sessionId);
         self.messageHandler.setSendMessage (send);
         self.messageHandler.setSeparator ("/");
     };

--- a/webinos/core/pzp/lib/pzp_otherManager.js
+++ b/webinos/core/pzp/lib/pzp_otherManager.js
@@ -50,7 +50,7 @@ var Pzp_OtherManager = function (_parent) {
      */
     function registerMessaging (pzhId) {
         if (_parent.pzp_state.connectedPzh[pzhId] && _parent.pzp_state.enrolled) {
-            var msg = self.messageHandler.registerSender(_parent.pzp_state.sessionId, pzhId);
+            var msg = self.messageHandler.createRegisterMessage(_parent.pzp_state.sessionId, pzhId);
             _parent.sendMessage (msg, pzhId);
         }
     }
@@ -201,7 +201,6 @@ var Pzp_OtherManager = function (_parent) {
         };
         self.rpcHandler.setSessionId (_parent.pzp_state.sessionId);
         self.messageHandler.setGetOwnId (_parent.pzp_state.sessionId);
-        self.messageHandler.setObjectRef (_parent);
         self.messageHandler.setSendMessage (send);
         self.messageHandler.setSeparator ("/");
     };

--- a/webinos/core/pzp/lib/pzp_sessionHandling.js
+++ b/webinos/core/pzp/lib/pzp_sessionHandling.js
@@ -427,7 +427,7 @@ var PzpServer = function (parent) {
         parent.setConnectState("peer", true);
         _conn.id = clientSessionId;
 
-        msg = parent.webinos_manager.messageHandler.registerSender (parent.pzp_state.sessionId, clientSessionId);
+        msg = parent.webinos_manager.messageHandler.createRegisterMessage (parent.pzp_state.sessionId, clientSessionId);
         parent.sendMessage (msg, clientSessionId);
         parent.sendUpdateToAll();
         logger.log ("pzp server - " + clientSessionId + " connected");
@@ -492,7 +492,7 @@ var PzpClient = function (parent) {
         parent.pzp_state.connectedPzp[_msg.name] = _client;
         parent.setConnectState("peer", true);
         _client.id = _msg.name;
-        var msg1 = parent.webinos_manager.messageHandler.registerSender (parent.pzp_state.sessionId, _msg.name);
+        var msg1 = parent.webinos_manager.messageHandler.createRegisterMessage (parent.pzp_state.sessionId, _msg.name);
         parent.sendMessage (msg1, _msg.name);
         parent.sendUpdatesendUpdateToAll();
         parent.pzpWebSocket.connectedApp();

--- a/webinos/core/pzp/lib/pzp_websocket.js
+++ b/webinos/core/pzp/lib/pzp_websocket.js
@@ -270,6 +270,7 @@ var PzpWSS = function (parent) {
         if (connectedWebApp[connection.id]) {
             delete connectedWebApp[connection.id];
             parent.webinos_manager.messageHandler.removeRoute (connection.id, parent.pzp_state.sessionId);
+            parent.webinos_manager.registry.emitEvent({name: 'disconnected', sessionId: connection.id});
             logger.log ("web client disconnected: " + connection.id + " due to " + reason);
         }
     }

--- a/webinos/core/wrt/lib/webinos.events.js
+++ b/webinos/core/wrt/lib/webinos.events.js
@@ -35,10 +35,10 @@
 		this.base(obj);
 		eventService = this;
 		this.idCount = 0;
-		//this.myAppID = "TestApp" + webinos.messageHandler.getOwnId();
+		//this.myAppID = "TestApp" + webinos.messageHandler.getOwnSessionId();
 
 		//TODO, this is the actuall messaging/session app id but should be replaced with the Apps unique ID (config.xml)
-		this.myAppID = webinos.messageHandler.getOwnId();
+		this.myAppID = webinos.messageHandler.getOwnSessionId();
 		console.log("MyAppID: " + this.myAppID);
 	};
 

--- a/webinos/core/wrt/lib/webinos.js
+++ b/webinos/core/wrt/lib/webinos.js
@@ -95,7 +95,6 @@
                 webinos.session.handleMsg (data);
             } else {
                 webinos.messageHandler.setGetOwnId (webinos.session.getSessionId ());
-                webinos.messageHandler.setObjectRef (this);
                 webinos.messageHandler.setSendMessage (webinos.session.message_send_messaging);
                 webinos.messageHandler.onMessageReceived (data, data.to);
             }

--- a/webinos/core/wrt/lib/webinos.js
+++ b/webinos/core/wrt/lib/webinos.js
@@ -94,7 +94,7 @@
             if (data.type === "prop") {
                 webinos.session.handleMsg (data);
             } else {
-                webinos.messageHandler.setGetOwnId (webinos.session.getSessionId ());
+                webinos.messageHandler.setOwnSessionId (webinos.session.getSessionId ());
                 webinos.messageHandler.setSendMessage (webinos.session.message_send_messaging);
                 webinos.messageHandler.onMessageReceived (data, data.to);
             }

--- a/webinos/core/wrt/lib/webinos.session.js
+++ b/webinos/core/wrt/lib/webinos.session.js
@@ -155,7 +155,7 @@
     }
   }
   function setWebinosMessaging() {
-    webinos.messageHandler.setGetOwnId(sessionId);
+    webinos.messageHandler.setOwnSessionId(sessionId);
     var msg = webinos.messageHandler.createRegisterMessage(sessionId, pzpId);
     webinos.session.message_send(msg, pzpId);
   }

--- a/webinos/core/wrt/lib/webinos.session.js
+++ b/webinos/core/wrt/lib/webinos.session.js
@@ -156,7 +156,7 @@
   }
   function setWebinosMessaging() {
     webinos.messageHandler.setGetOwnId(sessionId);
-    var msg = webinos.messageHandler.registerSender(sessionId, pzpId);
+    var msg = webinos.messageHandler.createRegisterMessage(sessionId, pzpId);
     webinos.session.message_send(msg, pzpId);
   }
   function updateConnected(message){


### PR DESCRIPTION
Implement a way to let RPC services know when WRT or app disconnects/disappears. That way these RPC services can stop sending continous messages to entities that don't exist anymore as e.g. the Geolocation API service does when watchPosition is called.

This is achieved in two ways.
1. If the service is on the same PZ entity where the WRT was connected to (by WebSocket) immediately deliver a 'disconnect' event to all registered services on this PZ entity.
2. If the sending service is on a different PZ entity, send back a message of the new message type 'mprop' letting the original sender know that the entity disconnected. Again deliver a 'disconnect' event to all registered services on the PZ entity this message was received on.

The Geolocation geoip service uses this feature as an example.

Includes the commits for WP-850 in PR #525, which should be merged first.

Jira-issue: [WP-851](http://jira.webinos.org/browse/WP-851)
