### PR TITLE
Start PZP service on platform initialisation

### DIFF
--- a/webinos/platform/android/app/assets/config/platform.properties
+++ b/webinos/platform/android/app/assets/config/platform.properties
@@ -1,9 +1,2 @@
-pzh.host.default: localhost
-pzh.name.default: 
-pzp.name.default: android
-auth_code.default: DEBUG
 pzp.cmd:data/data/org.webinos.app/node_modules/webinos/wp4/webinos_pzp.js
-pzp.cmd.pzh.host: --pzh-host=%pzh.host
-pzp.cmd.pzh.name: --pzh-name=%pzh.name
-pzp.cmd.pzp.name: --pzp-name=%pzp.name
-pzp.cmd.auth_code: --auth-code=%auth_code
+pzp.autoStart:true

--- a/webinos/platform/android/app/res/layout/pzp.xml
+++ b/webinos/platform/android/app/res/layout/pzp.xml
@@ -1,36 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
-    android:layout_height="wrap_content">
-	<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-		android:orientation="vertical" android:layout_width="fill_parent"
-		android:layout_height="fill_parent">
-		<TextView android:layout_height="wrap_content" android:text="@string/pzhHost"
-			android:layout_width="fill_parent" />
-		<EditText android:layout_height="wrap_content" android:id="@+id/args_pzhHost"
-			android:layout_width="match_parent" />
-		<TextView android:layout_height="wrap_content" android:text="@string/pzhName"
-			android:layout_width="fill_parent" />
-		<EditText android:layout_height="wrap_content" android:id="@+id/args_pzhName"
-			android:layout_width="match_parent" />
-		<TextView android:layout_height="wrap_content" android:text="@string/pzpName"
-			android:layout_width="fill_parent" />
-		<EditText android:layout_height="wrap_content" android:id="@+id/args_pzpName"
-			android:layout_width="match_parent" />
-		<TextView android:layout_height="wrap_content" android:text="@string/authCode"
-			android:layout_width="fill_parent" />
-		<EditText android:layout_height="wrap_content" android:id="@+id/args_authCode" android:inputType="textVisiblePassword"
-			android:layout_width="match_parent" />
-		<LinearLayout android:layout_height="wrap_content"
-			android:id="@+id/linearLayout1" android:layout_width="match_parent"
-			android:weightSum="1">
-			<Button android:id="@+id/start_button" android:layout_height="wrap_content"
-				android:text="@string/start" android:layout_width="wrap_content" />
-			<Button android:id="@+id/stop_button" android:layout_height="wrap_content"
-				android:text="@string/stop" android:layout_width="wrap_content" />
-			<TextView android:layout_height="wrap_content" android:id="@+id/args_stateText"
-				android:layout_width="105dp" android:layout_weight="0.54" />
-		</LinearLayout>
-	</LinearLayout>
+    android:layout_height="wrap_content" >
+
+    <LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:orientation="vertical" >
+
+        <LinearLayout
+            android:id="@+id/linearLayout1"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:weightSum="1" >
+
+            <Button
+                android:id="@+id/start_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/start" />
+
+            <Button
+                android:id="@+id/stop_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/stop" />
+
+            <TextView
+                android:id="@+id/args_stateText"
+                android:layout_width="105dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.54" />
+        </LinearLayout>
+
+        <CheckBox
+            android:id="@+id/auto_start"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/start_automatically" />
+    </LinearLayout>
+
 </ScrollView>

--- a/webinos/platform/android/app/res/values/strings.xml
+++ b/webinos/platform/android/app/res/values/strings.xml
@@ -3,13 +3,10 @@
     <string name="app_name">Webinos</string>
     <string name="pzp_activity_name">PZP</string>
     <string name="initialising_runtime">Initialising Webinos Runtime</string>
+    <string name="arguments">Arguments</string>
     <string name="start">Start</string>
     <string name="stop">Stop</string>
-    <string name="arguments">Arguments:</string>
-    <string name="pzhHost">PZH host name or IP address:</string>
-    <string name="pzhName">User name (OpenID):</string>
-    <string name="pzpName">Device name:</string>
-    <string name="authCode">Authorisation code:</string>
+    <string name="start_automatically">Start automatically</string>
     <string name="run_state">Run state</string>
     <string name="created">Created</string>
     <string name="uninitialised">Uninitialised</string>

--- a/webinos/platform/android/app/src/org/webinos/app/platform/PlatformInit.java
+++ b/webinos/platform/android/app/src/org/webinos/app/platform/PlatformInit.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.webinos.app.R;
+import org.webinos.app.pzp.PzpService;
 import org.webinos.util.AssetUtils;
 import org.webinos.util.ModuleUtils;
 import org.webinos.util.ModuleUtils.ModuleType;
@@ -210,6 +211,7 @@ public class PlatformInit extends Service {
 	public void onCreate() {
 		super.onCreate();
 		Config.init(this);
+		startService(new Intent(this, PzpService.class));
 	}
 	
 	/*******************

--- a/webinos/platform/android/app/src/org/webinos/app/pzp/ConfigActivity.java
+++ b/webinos/platform/android/app/src/org/webinos/app/pzp/ConfigActivity.java
@@ -34,7 +34,7 @@ import android.util.Log;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
-import android.widget.EditText;
+import android.widget.CheckBox;
 import android.widget.TextView;
 
 public class ConfigActivity extends Activity implements PzpServiceListener, PzpStateListener {
@@ -42,11 +42,8 @@ public class ConfigActivity extends Activity implements PzpServiceListener, PzpS
 	private PzpService pzpService;
 	private Button startButton;
 	private Button stopButton;
-	private EditText pzhHost;
-	private EditText pzhName;
-	private EditText pzpName;
-	private EditText authCode;
 	private TextView stateText;
+	private CheckBox autoStart;
 	private Handler viewHandler = new Handler();
 	private long uiThread;
 	
@@ -81,7 +78,6 @@ public class ConfigActivity extends Activity implements PzpServiceListener, PzpS
 			@Override
 			public void onClick(View v) {
 				Log.v(TAG, "startButton.onClick(): requesting PZP start");
-				updateConfigFromEditText();
 				pzpService.startPzp();
 			}
 		});
@@ -96,25 +92,18 @@ public class ConfigActivity extends Activity implements PzpServiceListener, PzpS
 			}
 		});
 
-		pzhHost = (EditText)findViewById(R.id.args_pzhHost);
-		String pzhHostText = configParams.pzhHost;
-		if(pzhHostText != null)
-			pzhHost.setText(pzhHostText);
+		autoStart = (CheckBox)findViewById(R.id.auto_start);
+		String autoStartText = configParams.autoStart;
+		if(autoStartText != null)
+			autoStart.setChecked("true".equals(autoStartText));
+		autoStart.setOnClickListener(new OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				Log.v(TAG, "startButton.onClick(): requesting PZP start");
+				updateConfigFromForm();
+			}
+		});
 
-		pzhName = (EditText)findViewById(R.id.args_pzhName);
-		String pzhNameText = configParams.pzhName;
-		if(pzhNameText != null)
-			pzhName.setText(pzhNameText);
-
-		pzpName = (EditText)findViewById(R.id.args_pzpName);
-		String pzpNameText = configParams.pzpName;
-		if(pzpNameText != null)
-			pzpName.setText(pzpNameText);
-
-		authCode = (EditText)findViewById(R.id.args_authCode);
-		String authCodeText = configParams.authCode;
-		if(authCodeText != null)
-			authCode.setText(authCodeText);
 
 		/* if the platform is not yet initialised, wait until that
 		 * has completed and retry */
@@ -132,12 +121,9 @@ public class ConfigActivity extends Activity implements PzpServiceListener, PzpS
 		}
 	}
 
-	private void updateConfigFromEditText() {
+	private void updateConfigFromForm() {
 		ConfigParams configParams = pzpService.getConfig();
-		configParams.pzhHost = pzhHost.getText().toString();
-		configParams.pzhName = pzhName.getText().toString();
-		configParams.pzpName = pzpName.getText().toString();
-		configParams.authCode = authCode.getText().toString();
+		configParams.autoStart = String.valueOf(autoStart.isChecked());
 		pzpService.updateConfig();
 	}
 


### PR DESCRIPTION
Jira issue: WP-283

This commit is the first of a series to address this issue.
Here the PZPService is unconditionally started by PlatformInit.
The PZPService in turn starts the PZP itself if the autoStart option
is enabled (which is the default). If the PZP does not auto-start,
it remains controllable via the PZPConfigActivity, which is now
accessible from the Settings option on the WidgetListActivity.

This commit does not yet synchronise with the startup event that
is emitted by the PZP, so it indicates the started state as soon
as the PZP isolate runs.

Further, this does not yet attempt to restart the PZP if it exits.
