### PR TITLE
Configures widget manager to store widget contents for serving

### DIFF
--- a/webinos/core/manager/widget_manager/lib/widgetmanager/config.js
+++ b/webinos/core/manager/widget_manager/lib/widgetmanager/config.js
@@ -56,7 +56,7 @@ this.Config = (function() {
   /* FIXME: remove nasty hack */
   var wrtHome;
 	if(process.platform == 'android')
-	  wrtHome = '/data/data/org.webinos.app/wrt';
+	  wrtHome = '/data/data/org.webinos.app/node_modules/webinos/wp4/webinos/web_root/apps/wrt';
   else if (process.platform == 'win32' || process.platform == 'linux' || process.platform == 'darwin') {
 		var path = require('path');
 		var webinos = require("find-dependencies")(__dirname);

--- a/webinos/platform/android/app/AndroidManifest.xml
+++ b/webinos/platform/android/app/AndroidManifest.xml
@@ -111,7 +111,10 @@
                 <action android:name="org.webinos.wrt.channel.SERVER" />
             </intent-filter>
         </service>
-        <provider android:name=".wrt.provider.WidgetContentProvider" android:authorities="org.webinos.wrt"></provider>
-        
+        <provider android:name=".wrt.provider.WidgetContentProvider" android:exported="true" android:authorities="org.webinos.wrt" android:readPermission="org.webinos.app.WgtReadPermission"></provider>
     </application>
+        <permission android:name="org.webinos.app.WgtReadPermission"
+        android:label="@string/permlab_wgtRead"
+        android:description="@string/permdesc_wgtRead"
+        android:protectionLevel="dangerous" />
 </manifest>

--- a/webinos/platform/android/app/res/values/strings.xml
+++ b/webinos/platform/android/app/res/values/strings.xml
@@ -40,5 +40,8 @@
     <string name="not_yet_implemented">Not yet implemented</string>
     <string name="no_apps_installed">No applications installed</string>
     <string name="loading_apps">Loading applications</string>
-    
+    <string name="permlab_wgtRead">read installed webinos widgets</string>
+    <string name="permdesc_wgtRead">Allows the application (a trusted web run times) to access
+        installed widgets contents without your intervention.</string>
+        
 </resources>

--- a/webinos/platform/android/build.xml
+++ b/webinos/platform/android/build.xml
@@ -35,7 +35,8 @@
 				node_modules/optimist/,
 				node_modules/JSV/,
 				webinos/web_root/webinos.js,
-				webinos/" 
+				webinos/,
+				webinos/web_root/apps/wrt/"
 			excludes="
 				webinos/platform/,
 				webinos/core/pzh/,
@@ -43,7 +44,6 @@
 				
                 webinos/web_root/tests/,
 				webinos/web_root/api_test_specs/,
-				webinos/web_root/apps/,
 				webinos/web_root/*.html,
 				webinos/web_root/*.xml,
 				webinos/web_root/*.json,


### PR DESCRIPTION
Changes the storage location so that widget contents can
be served easily via http rather then fetch via content
protocol (ContentProvider). Further investigation needed
if that change should replace the content provider in the
long term.

Jira issue: WP-895
