### PR TITLE
Enable pzp rename

### DIFF
--- a/webinos/core/pzp/lib/pzp_websocket.js
+++ b/webinos/core/pzp/lib/pzp_websocket.js
@@ -191,7 +191,7 @@ var PzpWSS = function (parent) {
                     parent.pzpWebSocket.connectedApp(connection, msg.payload.value);
                     break;
                 case "setFriendlyName":
-                    //parent.changeFriendlyName(msg.payload.value);
+                    parent.changeFriendlyName(msg.payload.value);
                     // THis functionality will be added via webinos core api.
                     break;
                 case "getFriendlyName":


### PR DESCRIPTION
Re enable pzp rename for living labs. This functionality is supported before registering to your pzh via the register widget.

Jira issue: WP-929
