### PR TITLE
PZP reconnectivity and enrollment fixes

### DIFF
--- a/webinos/core/manager/messaging/test/jasmine/messaging.spec.js
+++ b/webinos/core/manager/messaging/test/jasmine/messaging.spec.js
@@ -1,4 +1,4 @@
-describe('manager.messaging', function() {
+describe('messaging', function() {
 
 	var mockRpcHandler = jasmine.createSpyObj('rpcHandler', ['setMessageHandler', 'handleMessage']);
 	var MessageHandler = require('../../lib/messagehandler.js').MessageHandler;

--- a/webinos/core/pzh/lib/pzh_provider.js
+++ b/webinos/core/pzh/lib/pzh_provider.js
@@ -252,10 +252,9 @@ var Provider = function (_hostname, _friendlyName) {
         });
     };
 
-    /*// This keeps pzh running but you cannot find where error occurred
+    // This keeps pzh running but you cannot find where error occurred
      process.on("uncaughtException", function(err) {
      logger.error("uncaught exception " + err.message);
-     })*/
-    ;
+     });
 };
 module.exports = Provider;

--- a/webinos/core/pzh/lib/pzh_webSessionHandling.js
+++ b/webinos/core/pzh/lib/pzh_webSessionHandling.js
@@ -205,7 +205,7 @@ var pzhWI = function (pzhs, hostname, port, serverPort, addPzh, refreshPzh, getA
         if (userObj.pzh_state.sessionId !== obj.message.at) { // Different PZH
             var id = userObj.pzh_otherManager.addMsgListener (function (modules) {
                 sendMsg (conn, obj.user, { type:"listUnregServices",
-                    message                    :{"pzEntityId":obj.message.at, "modules":modules.services} });
+                    message:{"pzEntityId":obj.message.at, "modules":modules.services} });
             });
             var msg = userObj.prepMsg (obj.message.at, "listUnregServices", {listenerId:id});
             userObj.sendMessage (msg, obj.message.at);
@@ -213,7 +213,7 @@ var pzhWI = function (pzhs, hostname, port, serverPort, addPzh, refreshPzh, getA
             var data = require ("fs").readFileSync ("./webinos_config.json");
             var c = JSON.parse (data.toString ());
             sendMsg (conn, obj.user, { type:"listUnregServices",
-                message                    :{"pzEntityId":userObj.pzh_state.sessionId, "modules":c.pzhDefaultServices} }); // send default services...
+                message:{"pzEntityId":userObj.pzh_state.sessionId, "modules":c.pzhDefaultServices} }); // send default services...
         }
     }
 
@@ -498,10 +498,8 @@ var pzhWI = function (pzhs, hostname, port, serverPort, addPzh, refreshPzh, getA
     }
 
     function csrAuthCodeByPzp (conn, obj, userObj) {
-        userObj.enroll.addNewPZPCert (obj, refreshPzh, function (status, payload) {
-            if (status) {
-                sendMsg (conn, obj.user, { type:"csrAuthCodeByPzp", message:payload });
-            }
+        userObj.enroll.addNewPZPCert (obj, refreshPzh, function (payload) {
+            sendMsg (conn, obj.user, { type:"csrAuthCodeByPzp", message:payload });
         });
     }
 

--- a/webinos/core/pzhweb/public/js/view-enroll-pzp.js
+++ b/webinos/core/pzhweb/public/js/view-enroll-pzp.js
@@ -7,11 +7,11 @@ try {
 
 channel.onerror = function (error) {
 	console.error ("Connection Error: " + error.toString ());
-}
+};
 
 channel.onclose = function () {
 	console.log ("PZP Connection Closed");
-}
+};
 
 channel.onmessage = function (message) {
 	var data = JSON.parse (message.data);
@@ -24,8 +24,10 @@ channel.onmessage = function (message) {
 				if (msg !== "") {
 					var parse = JSON.parse(msg);
 					channel.send(JSON.stringify(parse.message));
-					window.location.href = "http://localhost:"+templateData.pzpPort+"/testbed/client.html";
-					channel.close();
+                    if (parse.message.payload.status === "signedCertByPzh" || parse.message.payload.status === "error") {
+						window.location.href = "http://localhost:"+templateData.pzpPort+"/testbed/client.html";
+						channel.close();
+					}
 				}
 			 }
 		 }
@@ -33,7 +35,7 @@ channel.onmessage = function (message) {
 		 req.setRequestHeader ("Content-Type", "application/json");
 		 req.send(JSON.stringify({authCode:data.payload.authCode, csr:data.payload.csr, from:data.from}));
 	}
-}
+};
 
 channel.onopen = function() {
 	console.log("connection successful");
@@ -43,4 +45,4 @@ channel.onopen = function() {
 		authCode:templateData.authCode,
 		providerDetails:((templateData.port !== '443') ? (templateData.address+":"+templateData.port) : templateData.address)}};
 	channel.send(JSON.stringify(data));
-}
+};

--- a/webinos/core/pzp/lib/pzp_websocket.js
+++ b/webinos/core/pzp/lib/pzp_websocket.js
@@ -210,7 +210,21 @@ var PzpWSS = function (parent) {
                 case "authCodeByPzh":
                     if (expectedPzhAddress === msg.payload.providerDetails) {
                         connection.sendUTF (JSON.stringify ({"from":parent.config.metaData.webinosName,
-                            "payload":{"status":"csrAuthCodeByPzp", "csr":parent.config.cert.internal.master.csr, "authCode":msg.payload.authCode}}));
+                            "payload":{"status":"csrAuthCodeByPzp", 
+                                       "csr":parent.config.cert.internal.master.csr}}));
+                    }
+                    break;
+                case "pzpId_Update":
+                    if (expectedPzhAddress === (msg.from && msg.from.split("_") && msg.from.split("_")[0])) {
+                        // Re-Generate Master CSR and send it to PZH..
+                        parent.config.metaData.webinosName = msg.payload.message;
+                        parent.createPzpCertificates(function(){
+		                    parent.setSessionId();
+		                    // set device name
+		                    connection.sendUTF (JSON.stringify ({"from":parent.config.metaData.webinosName,
+		                        "payload":{"status":"csrAuthCodeByPzp", 
+		                         "csr":parent.config.cert.internal.master.csr}}));
+						});
                     }
                     break;
                 case "signedCertByPzh":


### PR DESCRIPTION
Checks PZH every 20 seconds even if connected. If PZH is not available does socket.destroy to facilitate service discovery to only work on device.
If 2 PZP with same name enroll, PZH assigns a new id to the PZP. PZP then regenerates csr and get it signed by the PZH.

Jira Issue: WP-909
