### PR TITLE
Move widgetmanager to PZP isolate on Android

### DIFF
--- a/webinos/core/api/applauncher/lib/applauncher.js
+++ b/webinos/core/api/applauncher/lib/applauncher.js
@@ -20,7 +20,8 @@
   var androidLauncher = null;
   var widgetLibrary;
   var open;
-  try { widgetLibrary = require('../../../manager/widget_manager/index.js'); open = require('open'); } catch(e) { widgetLibrary = null; }
+  try { widgetLibrary = require('../../../manager/widget_manager/index.js'); } catch(e) { widgetLibrary = null; }
+  try { open = require('open'); } catch(e) { open = null; }
 
   if (process.platform == 'android') {
     androidLauncher = require('bridge').load('org.webinos.impl.AppLauncherManagerImpl', this);

--- a/webinos/core/api/applauncher/lib/applauncher.js
+++ b/webinos/core/api/applauncher/lib/applauncher.js
@@ -24,13 +24,13 @@
   try { open = require('open'); } catch(e) { open = null; }
 
   if (process.platform == 'android') {
-    androidLauncher = require('bridge').load('org.webinos.impl.AppLauncherManagerImpl', this);
 	if(widgetLibrary) {
 	  /* start up the Android-side widgetmanager service */
       process.env.WRT_HOME = '/data/data/org.webinos.app/wrt';
       var bridgewm = require('bridge').load('org.webinos.app.wrt.mgr.WidgetManagerImpl', this);
       bridgewm.setWidgetProcessor(widgetLibrary.widgetmanager);
     }
+    androidLauncher = require('bridge').load('org.webinos.impl.AppLauncherManagerImpl', this);
   }
 
   var dependencies = require("find-dependencies")(__dirname);

--- a/webinos/core/api/applauncher/lib/applauncher.js
+++ b/webinos/core/api/applauncher/lib/applauncher.js
@@ -20,12 +20,16 @@
   var androidLauncher = null;
   var widgetLibrary;
   var open;
+  try { widgetLibrary = require('../../../manager/widget_manager/index.js'); open = require('open'); } catch(e) { widgetLibrary = null; }
+
   if (process.platform == 'android') {
     androidLauncher = require('bridge').load('org.webinos.impl.AppLauncherManagerImpl', this);
-    /* FIXME: temporarily disable widgetmanager in this isolate */
-    widgetLibrary = null;
-  } else {
-    try { widgetLibrary = require('../../../manager/widget_manager/index.js'); open = require('open'); } catch(e) { widgetLibrary = null; }
+	if(widgetLibrary) {
+	  /* start up the Android-side widgetmanager service */
+      process.env.WRT_HOME = '/data/data/org.webinos.app/wrt';
+      var bridgewm = require('bridge').load('org.webinos.app.wrt.mgr.WidgetManagerImpl', this);
+      bridgewm.setWidgetProcessor(widgetLibrary.widgetmanager);
+    }
   }
 
   var dependencies = require("find-dependencies")(__dirname);

--- a/webinos/platform/android/app/AndroidManifest.xml
+++ b/webinos/platform/android/app/AndroidManifest.xml
@@ -106,6 +106,7 @@
         <service android:exported="true" android:enabled="true" android:name=".anode.AnodeService" android:description="@string/anode_service_description" android:label="@string/anode_service"></service>
         <service android:exported="true" android:enabled="true" android:name=".platform.PlatformInit" android:description="@string/platform_service_description" android:label="@string/pzp_service"></service>
         <service android:exported="true" android:enabled="true" android:name=".pzp.PzpService" android:description="@string/pzp_service_description" android:label="@string/pzp_service"></service>
+        <service android:exported="true" android:enabled="true" android:name=".wrt.mgr.WidgetManagerService" android:description="@string/wgtmgr_service_description" android:label="@string/wgtmgr_service"></service>
         <service android:name=".wrt.channel.WebinosSocketService">
             <intent-filter>
                 <action android:name="org.webinos.wrt.channel.SERVER" />

--- a/webinos/platform/android/app/res/values/strings.xml
+++ b/webinos/platform/android/app/res/values/strings.xml
@@ -17,9 +17,11 @@
     <string name="anode_receiver_description">A broadcast receiver for controlling invocations of node.js</string>
     <string name="anode_service">Anode Service</string>
     <string name="pzp_service">Webinos PZP Service</string>
+    <string name="wgtmgr_service">Webinos Widget Manager Service</string>
     <string name="platform_service">Webinos Platform Service</string>
     <string name="anode_service_description">A service that permits the running of node.js invocations in the background</string>
     <string name="pzp_service_description">A service that controls the execution and lifecycle of the Webinos PZP</string>
+    <string name="wgtmgr_service_description">A service that controls the execution and lifecycle of Webinos Applications</string>
     <string name="platform_service_description">A service that controls the execution and lifecycle of the Webinos core platform</string>
     <string name="downloading_widget">Downloading application</string>
     <string name="installing_widget">Installing application</string>

--- a/webinos/platform/android/app/src/org/webinos/app/pzp/ConfigActivity.java
+++ b/webinos/platform/android/app/src/org/webinos/app/pzp/ConfigActivity.java
@@ -54,12 +54,7 @@ public class ConfigActivity extends Activity implements PzpServiceListener, PzpS
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.pzp);
 		uiThread = viewHandler.getLooper().getThread().getId();
-		pzpService = PzpService.getService(this, this);
-		if(pzpService != null) {
-			Log.v(TAG, "onCreate(): service already running");
-			initUI();
-			return;
-		}
+		PzpService.getService(this, this);
 	}
 
 	@Override

--- a/webinos/platform/android/app/src/org/webinos/app/wrt/mgr/WidgetManagerImpl.java
+++ b/webinos/platform/android/app/src/org/webinos/app/wrt/mgr/WidgetManagerImpl.java
@@ -22,12 +22,17 @@ package org.webinos.app.wrt.mgr;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import org.meshpoint.anode.AndroidContext;
 import org.meshpoint.anode.module.IModule;
 import org.meshpoint.anode.module.IModuleContext;
+import org.webinos.app.wrt.mgr.WidgetManagerService.WidgetManagerServiceListener;
+
+import android.content.Context;
 
 public class WidgetManagerImpl extends WidgetManager implements IModule {
 	
 	private WidgetProcessor processor;
+	private Context androidContext;
 	
 	/*****************************
 	 * WidgetManager change events
@@ -64,9 +69,14 @@ public class WidgetManagerImpl extends WidgetManager implements IModule {
 	 *****************************/
 
 	@Override
-	public void setWidgetProcessor(WidgetProcessor processor) {
+	public void setWidgetProcessor(final WidgetProcessor processor) {
 		this.processor = processor;
-		WidgetManagerService.onStarted(this);
+		if(true)
+		WidgetManagerService.getService(androidContext, new WidgetManagerServiceListener() {
+			@Override
+			public void onServiceAvailable(WidgetManagerService service) {
+				service.setWidgetManager(WidgetManagerImpl.this);
+			}});
 	}
 
 	/*****************************
@@ -74,6 +84,7 @@ public class WidgetManagerImpl extends WidgetManager implements IModule {
 	 *****************************/
 	@Override
 	public Object startModule(IModuleContext ctx) {
+		androidContext = ((AndroidContext)ctx).getAndroidContext();
 		return this;
 	}
 

--- a/webinos/platform/android/app/src/org/webinos/app/wrt/mgr/WidgetManagerService.java
+++ b/webinos/platform/android/app/src/org/webinos/app/wrt/mgr/WidgetManagerService.java
@@ -73,7 +73,10 @@ public class WidgetManagerService {
 				result = theManager;
 			} else if(listener != null) {
 				listeners.add(listener);
-				startInstance(ctx);
+				/* we do't need to explicitly start the widgetmanager
+				 * in a separate isolate; it will be started by the
+				 * PZP
+				startInstance(ctx); */
 			}
 		}
 		return result;

--- a/webinos/platform/android/app/src/org/webinos/app/wrt/mgr/WidgetManagerService.java
+++ b/webinos/platform/android/app/src/org/webinos/app/wrt/mgr/WidgetManagerService.java
@@ -20,28 +20,110 @@
 package org.webinos.app.wrt.mgr;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.meshpoint.anode.bridge.Env;
-import org.webinos.app.anode.AnodeReceiver;
-import org.webinos.app.anode.AnodeService;
 import org.webinos.app.platform.PlatformInit;
-import org.webinos.util.AssetUtils;
-import org.webinos.util.Constants;
+import org.webinos.app.pzp.PzpService;
 
+import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
+import android.os.IBinder;
 
-public class WidgetManagerService {
-    private static ArrayList<LaunchListener> listeners = new ArrayList<LaunchListener>();
-	private static WidgetManagerImpl theManager;
+public class WidgetManagerService extends Service {
+	private static final String TAG = WidgetManagerService.class.getCanonicalName();
 
-    private static final String TAG = "org.webinos.app.wrt.mgr.WidgetManagerService";
-	
-	public static WidgetManagerImpl getInstance() {
+	private ArrayList<WidgetManagerLaunchListener> wgtMgrListeners = new ArrayList<WidgetManagerLaunchListener>();
+	private WidgetManagerImpl theManager;
+
+	/**
+	 * The singleton service
+	 */
+	private static WidgetManagerService theService;
+
+	/**
+	 * Listener for asynchronous indications of service availability
+	 */
+	interface WidgetManagerServiceListener {
+		public void onServiceAvailable(WidgetManagerService service);
+	}
+
+	/**
+	 * Listeners waiting for widgetmanager availability
+	 */
+	public interface WidgetManagerLaunchListener {
+		public void onLaunch(WidgetManagerImpl mgr);
+	}
+
+	/**
+	 * Listeners waiting for service availability
+	 */
+	private static List<WidgetManagerServiceListener> serviceListeners = new ArrayList<WidgetManagerServiceListener>();
+
+	/**
+	 * Synchronously obtain the service instance, if it already exists.
+	 * This will not trigger the service being started; only use in contexts
+	 * where it is known that the service will already have been started.
+	 * @return the service instance if available
+	 */
+	static synchronized WidgetManagerService getService() { return theService; }
+
+	/**
+	 * Get the service instance, registering a callback for the case that
+	 * the service is not currently available. If not available, the service
+	 * will be started.
+	 * @param ctx a context to use to start the service if required.
+	 * @param listener a listener to call with the service instance, in the case that
+	 * the service was not available already. If the service was available at the time
+	 * the call was made, then the instance will be returned directly and the listener
+	 * will NOT be called.
+	 * @return the service instance if available; or null otherwise
+	 */
+	static void getService(Context ctx, WidgetManagerServiceListener listener) {
+		WidgetManagerService foundService = null;
+		/* synchronously check, and add listener if necessary */
+		synchronized(WidgetManagerService.class) {
+			if(theService == null) {
+				serviceListeners.add(listener);
+			}
+			foundService = theService;
+		}
+		/* start service if necessary */
+		if(foundService == null) {
+			ctx.startService(new Intent(ctx, WidgetManagerService.class));
+		} else {
+			listener.onServiceAvailable(foundService);
+		}
+	}
+
+	@Override
+	public void onCreate() {
+		super.onCreate();
+		/* ensure the PZP service is started, in case nobody else did */
+		PzpService.getService(this, null);
+		/* synchronously set ourselves as the singleton instance, and notify
+		 * and pending listeners */
+		synchronized(WidgetManagerService.class) {
+			theService = this;
+			for(WidgetManagerServiceListener listener : serviceListeners)
+				listener.onServiceAvailable(theService);
+			serviceListeners = null;
+		}
+	}
+
+	public synchronized void setWidgetManager(WidgetManagerImpl mgr) {
+		theManager = mgr;
+		if(wgtMgrListeners.size() > 0)
+			for(WidgetManagerLaunchListener listener : wgtMgrListeners)
+				listener.onLaunch(mgr);
+		wgtMgrListeners = null;
+	}
+
+	public WidgetManagerImpl getWidgetManager() {
 		return theManager;
 	}
-	
+
 	private static void startInstance(final Context ctx) {
 		try {
 			/* if the platform is not yet initialised, wait until that
@@ -67,31 +149,38 @@ public class WidgetManagerService {
 		}
 	}
 
-	public static WidgetManagerImpl getInstance(Context ctx, LaunchListener listener) {
-		WidgetManagerImpl result = null;
-		synchronized(listeners) {
-			if(theManager != null) {
-				result = theManager;
-			} else if(listener != null) {
-				listeners.add(listener);
-				startInstance(ctx);
-			}
+	public static WidgetManagerImpl getWidgetManagerInstance(Context ctx, final WidgetManagerLaunchListener listener) {
+		WidgetManagerImpl result;
+		/* if we have the service and wgtmgr already, return it */
+		if(theService != null && (result = theService.getWidgetManager()) != null)
+			return result;
+
+		/* otherwise, get the service asynchronously, and then get the wgtmgr */
+		if(listener != null) {
+			getService(ctx, new WidgetManagerServiceListener() {
+				@Override
+				public void onServiceAvailable(WidgetManagerService service) {
+					synchronized(service) {
+						WidgetManagerImpl result = service.getWidgetManager();
+						if(result != null) {
+							listener.onLaunch(result);
+							return;
+						}
+						service.wgtMgrListeners.add(listener);
+					}
+				}
+			});
 		}
-		return result;
+		return null;
 	}
 	
-	static void onStarted(WidgetManagerImpl mgr) {
-		theManager = mgr;
-        synchronized(listeners) {
-        	for(LaunchListener listener : listeners) {
-        		listener.onLaunch(mgr);
-        		listeners.remove(listener);
-        	}
-        }
+	public static WidgetManagerImpl getWidgetManagerInstance() {
+		return getWidgetManagerInstance(null, null);
 	}
 
-	public interface LaunchListener {
-		public void onLaunch(WidgetManagerImpl mgr);
+	@Override
+	public IBinder onBind(Intent arg0) {
+		return null;
 	}
 
 }

--- a/webinos/platform/android/app/src/org/webinos/app/wrt/mgr/WidgetManagerService.java
+++ b/webinos/platform/android/app/src/org/webinos/app/wrt/mgr/WidgetManagerService.java
@@ -54,13 +54,14 @@ public class WidgetManagerService {
 			})) {
 				return;
 			}
+			/* temp - don't launch in separate isolate
 			String launchScript = Constants.RESOURCE_DIR + "/widgetmanager.js";
 			AssetUtils.writeAssetToFile(ctx,"js/widgetmanager.js", launchScript);
 			Intent intent = new Intent(ctx, AnodeService.class);
 			Log.v(TAG, launchScript);
 			intent.setAction(AnodeReceiver.ACTION_START);
 			intent.putExtra(AnodeReceiver.CMD, launchScript);
-			ctx.startService(intent);
+			ctx.startService(intent); */
 		} catch(Throwable t) {
 			Env.logger.e(TAG, "Unable to start widgetmanager", t);
 		}
@@ -73,10 +74,7 @@ public class WidgetManagerService {
 				result = theManager;
 			} else if(listener != null) {
 				listeners.add(listener);
-				/* we do't need to explicitly start the widgetmanager
-				 * in a separate isolate; it will be started by the
-				 * PZP
-				startInstance(ctx); */
+				startInstance(ctx);
 			}
 		}
 		return result;

--- a/webinos/platform/android/app/src/org/webinos/app/wrt/ui/WidgetDownloadActivity.java
+++ b/webinos/platform/android/app/src/org/webinos/app/wrt/ui/WidgetDownloadActivity.java
@@ -27,7 +27,7 @@ import java.net.URISyntaxException;
 import org.webinos.app.R;
 import org.webinos.app.wrt.mgr.WidgetManagerImpl;
 import org.webinos.app.wrt.mgr.WidgetManagerService;
-import org.webinos.app.wrt.mgr.WidgetManagerService.LaunchListener;
+import org.webinos.app.wrt.mgr.WidgetManagerService.WidgetManagerLaunchListener;
 import org.webinos.util.ModuleUtils;
 
 import android.app.Activity;
@@ -88,7 +88,7 @@ public class WidgetDownloadActivity extends Activity {
 		final Intent installIntent = new Intent();
 		installIntent.setClass(this, WidgetInstallActivity.class);
 		installIntent.putExtra("path", new String[]{path});
-		WidgetManagerImpl widgetMgr = WidgetManagerService.getInstance(this, new LaunchListener() {
+		WidgetManagerImpl widgetMgr = WidgetManagerService.getWidgetManagerInstance(this, new WidgetManagerLaunchListener() {
 			@Override
 			public void onLaunch(WidgetManagerImpl mgr) {
 				startActivityForResult(installIntent, 0);

--- a/webinos/platform/android/app/src/org/webinos/app/wrt/ui/WidgetInstallActivity.java
+++ b/webinos/platform/android/app/src/org/webinos/app/wrt/ui/WidgetInstallActivity.java
@@ -35,7 +35,7 @@ import android.os.Bundle;
 import android.os.Looper;
 import android.util.Log;
 
-public class WidgetInstallActivity extends Activity implements WidgetManagerService.LaunchListener {
+public class WidgetInstallActivity extends Activity implements WidgetManagerService.WidgetManagerLaunchListener {
 	
 	private static final int INSTALL_PROGRESS_DIALOG = 1;
 	private static final String TAG = "org.webinos.app.wrt.ui.WidgetInstallActivity";
@@ -45,7 +45,7 @@ public class WidgetInstallActivity extends Activity implements WidgetManagerServ
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		final WidgetManagerImpl widgetMgr = WidgetManagerService.getInstance(this, this);
+		final WidgetManagerImpl widgetMgr = WidgetManagerService.getWidgetManagerInstance(this, this);
 		if(widgetMgr != null)
 			onWidgetManagerAvailable(widgetMgr);
 	}

--- a/webinos/platform/android/app/src/org/webinos/app/wrt/ui/WidgetListAdapter.java
+++ b/webinos/platform/android/app/src/org/webinos/app/wrt/ui/WidgetListAdapter.java
@@ -55,7 +55,7 @@ public class WidgetListAdapter extends ArrayAdapter<String> {
 		
 		/* decide what to show as the main label text */
 		String labelText = null;
-		WidgetConfig widgetConfig = WidgetManagerService.getInstance().getWidgetConfig(installId);
+		WidgetConfig widgetConfig = WidgetManagerService.getWidgetManagerInstance().getWidgetConfig(installId);
 		if(widgetConfig == null) {
 			labelText = "widgetConfig is null - widget not properly installed";
 			return rowView;
@@ -109,7 +109,7 @@ public class WidgetListAdapter extends ArrayAdapter<String> {
 		if(prefIcon == null || prefIcon.isEmpty()) {
 			imageView.setImageResource(R.drawable.webinos_icon);
 		} else {
-			String iconPath = WidgetManagerService.getInstance().getWidgetDir(installId) + '/' + prefIcon;
+			String iconPath = WidgetManagerService.getWidgetManagerInstance().getWidgetDir(installId) + '/' + prefIcon;
 			imageView.setImageDrawable(Drawable.createFromPath(iconPath));
 		}
 

--- a/webinos/platform/android/app/src/org/webinos/app/wrt/ui/WidgetUninstallActivity.java
+++ b/webinos/platform/android/app/src/org/webinos/app/wrt/ui/WidgetUninstallActivity.java
@@ -34,7 +34,7 @@ public class WidgetUninstallActivity extends Activity {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		final WidgetManagerImpl widgetMgr = WidgetManagerService.getInstance();
+		final WidgetManagerImpl widgetMgr = WidgetManagerService.getWidgetManagerInstance();
 		if(widgetMgr == null)
 			throw new RuntimeException("WidgetUninstallActivity.onCreate(): unable to get WidgetManager");
 


### PR DESCRIPTION
This change ensures that the Widgetmanager is started in the PZP isolate an no longer in a separate isolate. The allows the AppLauncher to launch widgets directly (previously disabled) and should also address the occasional (still untraced) crash arising from objects being shared between isolates.
