### PR TITLE
Allow insecure password login for demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   , "passport": "x.x.x"
   , "passport-yahoo": "x.x.x"
   , "passport-google": "x.x.x"
+  , "passport-local": "x.x.x"
   , "open": "x.x.x"
   , "serialport": "x.x.x"
   }

--- a/webinos/core/pzhweb/app.js
+++ b/webinos/core/pzhweb/app.js
@@ -30,8 +30,10 @@ PzhProviderWeb.startWebServer = function (host, address, port, config, cb) {
             https = require('https'),
             fs = require('fs'),
             passport = require('passport'),
+            LocalStrategy = require('passport-local').Strategy,
             YahooStrategy = require('passport-yahoo').Strategy,
             GoogleStrategy = require('passport-google').Strategy;
+            
     } catch (err) {
         console.log("missing modules in pzh webserver, please run npm install and try again");
     }
@@ -160,6 +162,7 @@ PzhProviderWeb.startWebServer = function (host, address, port, config, cb) {
             app.use(express.session({ secret:sessionSecret }));//, store: new MemStore({reapInterval: 6000 * 10})
             app.use(passport.initialize());
             app.use(passport.session());
+            app.locals.pretty=true;
             app.use(app.router);
             app.use(express.static(__dirname + '/public'));
         });
@@ -231,6 +234,31 @@ PzhProviderWeb.startWebServer = function (host, address, port, config, cb) {
                 });
             }
         ));
+        
+        passport.use(new LocalStrategy(
+            function(username, password, done) {
+                if (username === "") {
+                  console.log("Username: " + username + " - empty");
+                  return done(null, false, { message: 'Please enter a username.' });
+                } else {
+                  return done(null, {
+                    "id":1,
+                    "from":"local",
+                    "displayName":username,
+                    "internal":true,
+                    "name": { 
+                      "familyName": username, 
+                      "givenName": "" 
+                    },
+                    "password":password,
+                    "identifier":"local-"+username,
+                    "emails": [ {"value" : username } ]
+                  });
+                }
+            }
+        ));
+        
+        
         return passport;
     }
 

--- a/webinos/core/pzhweb/package.json
+++ b/webinos/core/pzhweb/package.json
@@ -10,6 +10,7 @@
     "passport": ">= 0.1.15",
     "passport-yahoo": "*",
     "passport-google": "*",
+    "passport-local": "*",
     "optimist": "*",
     "jade": "*"
   }

--- a/webinos/core/pzhweb/public/css/structure.css
+++ b/webinos/core/pzhweb/public/css/structure.css
@@ -31,11 +31,11 @@ body {
 }
 
 .box.login {
-    height: 260px;
+    height: 460px;
     width: 400px;
     position: absolute;
     left: 50%;
-    top: 50%;
+    top: 30%;
     margin: -130px 0 0 -200px;
 }
 

--- a/webinos/core/pzhweb/routes/index.js
+++ b/webinos/core/pzhweb/routes/index.js
@@ -22,6 +22,7 @@ module.exports = function (app, address, port, state) {
         logger = dependency.global.require(dependency.global.util.location, "lib/logging.js")(__filename) || console,
         pzhadaptor = require('../pzhadaptor.js'),
         passport = require('passport'),
+        util = require("util"),
         helper = require('./helper.js');
 
     app.get('/', ensureAuthenticated, function (req, res) {
@@ -192,6 +193,18 @@ module.exports = function (app, address, port, state) {
         }
         res.render('login', { user:req.user });
     });
+    
+    app.post('/loginlocal', 
+        passport.authenticate('local', { 
+            successRedirect: '/',
+            failureRedirect: '/login',
+            failureFlash: false 
+        }),
+        function (req, res) {
+          res.redirect('/');
+        }
+    );
+    
     // GET /auth/google
     //   Use passport.authenticate() as route middleware to authenticate the
     //   request.  The first step in Google authentication will involve redirecting

--- a/webinos/core/pzhweb/views/login.jade
+++ b/webinos/core/pzhweb/views/login.jade
@@ -18,20 +18,30 @@ html
       }
 
   body
-    form.box.login
+    .box.login
       header
         img(src="http://webinos.org/wp-content/themes/parallelus-unite/images/webinos_logo.png", width="100px")
         label Personal Zone Hub login
         // <label>Please login to you personal zone hub using one of the following methods.</label>
         // TODO: "If you do not have an account, click..."
         // TODO: Fix stylesheet so that addition text can be added here if necessary
-      fieldset.boxBody
-        label Login using your Google ID
-        img(src='https://ssl.gstatic.com/images/logos/google_logo_41.png', width="100px")
-        input(type="button", class="btnLogin", onclick="loginGoogle()", value="Login via Google")
-        label Login using your Yahoo! ID
-        img(src='http://l.yimg.com/a/images/ww/met/slimheader/yahoo-logo-sm-png8.png', width="100px")
-        input(type="button", class="btnLogin", onclick="loginYahoo()", value="Login via Yahoo!")
+      form
+        fieldset.boxBody
+          label Login using your Google ID
+          img(src='https://ssl.gstatic.com/images/logos/google_logo_41.png', width="100px")
+          input(type="button", class="btnLogin", onclick="loginGoogle()", value="Login via Google")
+          label Login using your Yahoo! ID
+          img(src='http://l.yimg.com/a/images/ww/met/slimheader/yahoo-logo-sm-png8.png', width="100px")
+          input(type="button", class="btnLogin", onclick="loginYahoo()", value="Login via Yahoo!")
+      form(action="/loginlocal", method="POST")
+        fieldset.boxBody
+          label Login with a username and password
+          p Username
+            input(type="text",name="username", value="user@test.webinos.org")
+          p Password
+            input(type="password",name="password",value="test")
+            input(type="submit",value="Login!", class="btnLogin")
+        
     footer#main
       a(href="http://www.webinos.org") Powered by webinos
       |  |


### PR DESCRIPTION
The PZH web server now allows arbitrary login through
usernames and passwords.  This is to support the FIA
demos where access to OpenID is unreliable.

package.json now adds 'passport-local' as a required npm module
app.js loads the passport-local module
The CSS and view have been changed to offer this facility

Note that enrolment and certificate exchange probably doesn't work.

Andrea/Christos: Please let me know if this solves the problem.  Obviously this should be reverted once the demo is over.

Jira issue: unknown (JIRA down)
